### PR TITLE
fix: CI 构建时写入 .env 文件，修复 product 构建使用 beta 配置的问题

### DIFF
--- a/.github/workflows/electron-build-template.yml
+++ b/.github/workflows/electron-build-template.yml
@@ -285,6 +285,9 @@ jobs:
                   BYPASS_API_URL: ${{ inputs.bypassApiUrl }}
                   BUILD_STAGE: ${{ inputs.buildStage }}
 
+            - name: Write .env file (写入运行时环境变量)
+              run: echo "BUILD_STAGE=${{ inputs.buildStage }}" > dist/.env
+
             - name: Configure update URL (配置更新 URL 和文件名)
               id: configure_build
               uses: actions/github-script@v7


### PR DESCRIPTION
## 摘要

- CI 工作流 `electron-build-template.yml` 分步构建时缺少写入 `dist/.env` 的步骤
- 导致打包后的应用主进程 `process.env.BUILD_STAGE` 为 `undefined`，`getCurrentEnv()` 回退到 `beta` 配置
- 在 "Build Renderer" 和 "Configure update URL" 之间新增写入 `.env` 文件的步骤

## 测试计划

- [ ] 触发 product 构建，验证打包后应用主进程使用正确的 product 配置（API 地址为 `https://xtools.xbotaio.com/api`）
- [ ] 触发 beta 构建，验证打包后应用主进程使用正确的 beta 配置

🤖 Generated with [Claude Code](https://claude.com/claude-code)