### PR TITLE
🏰 chore(ci): 移除 dispatch 模板中的版本更新步骤，避免重复 bump

### DIFF
--- a/.github/workflows/tauri-build-template-dispatch.yml
+++ b/.github/workflows/tauri-build-template-dispatch.yml
@@ -74,16 +74,6 @@ jobs:
           cd $repo_name 
           git rev-parse HEAD
 
-      - name: Setup Node.js  environment
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ inputs.nodeVersion }}
-      - name: Increment version
-        id: version
-        run: |
-          npm install -g pnpm
-          pnpm update-version
-
       - name: Set PR body based on repository
         id: pr_body
         run: |
@@ -101,8 +91,6 @@ jobs:
         id: cpr
         with:
           add-paths: |
-            package.json
-            src-tauri/*
             ${{ steps.update_submodule.outputs.repo_name }}
           commit-message: "[create-pull-request] ${{ github.event.client_payload.message }}"
           title: "[create-pull-request] ${{ github.event.client_payload.message }}"


### PR DESCRIPTION
## 变更摘要

- 移除 `tauri-build-template-dispatch.yml` 中的 `Setup Node.js` 和 `Increment version`（`pnpm update-version`）步骤
- 精简 `add-paths`，仅保留子模块路径

## 原因

子模块更新时版本被重复 bump 了两次：
1. dispatch 模板中的 `pnpm update-version` 做一次
2. PR 合并后 `auto-version-bump-with-labels.yml` 又做一次

导致版本号跳跃（如 0.3.7 → 0.3.9）。移除 dispatch 模板中的版本更新，统一由 PR 合并后的工作流负责。

## 测试计划

- [ ] 验证子模块更新 dispatch 触发后 PR 只包含子模块变更
- [ ] 验证 PR 合并后版本号正确递增（不再跳跃）