### PR TITLE
fix(workflow): 修复工作流中的上传重试机制

### DIFF
--- a/.github/workflows/rust-exe-update-template-test.yml
+++ b/.github/workflows/rust-exe-update-template-test.yml
@@ -198,7 +198,7 @@ jobs:
         if: steps.upload_1.outcome == 'failure' && steps.upload_2.outcome == 'failure' && steps.upload_3.outcome == 'failure'
         shell: powershell
         run: |
-          Write-Host "Upload artifact 连续 3 次失败"
+          Write-Host "Upload artifact failed 3 times in a row"
           exit 1
 
       - name: 设置 packed 上传参数
@@ -209,14 +209,85 @@ jobs:
           $name = '${{ inputs.packageName }}-${{ inputs.buildStage }}-${{ github.ref_name }}-${{ github.sha }}-packed.exe'
           echo "artifact_name=$name" >> $env:GITHUB_OUTPUT
 
-      - name: Upload packed artifact
+      - name: Upload packed artifact (尝试 1/3)
         if: inputs.usePack == 'true' && inputs.buildStage == 'product'
+        id: upload_packed_1
         uses: actions/upload-artifact@v4
         timeout-minutes: 5
+        continue-on-error: true
         with:
           name: ${{ steps.upload_params_packed.outputs.artifact_name }}
           path: ${{ steps.target_parent_path.outputs.PARENT_PATH }}/target/${{ inputs.buildStage }}/release/packed/${{ inputs.packageName }}.exe
           overwrite: true
+
+      - name: Upload packed artifact 第 1 次失败通知
+        if: inputs.usePack == 'true' && inputs.buildStage == 'product' && steps.upload_packed_1.outcome == 'failure'
+        uses: foxundermoon/feishu-action@v2
+        with:
+          url: ${{ secrets.webhookFeishu }}
+          msg_type: post
+          content: |
+            post:
+              zh_cn:
+                title: ⚠️ ${{ inputs.projectName }} Upload packed artifact 失败 (1/3)，自动重试中...
+                content:
+                - - tag: text
+                    un_escape: true
+                    text: '部署环境: ${{ inputs.buildStage }}'
+                - - tag: text
+                    text: '部署链接: '
+                  - tag: a
+                    text: github action
+                    href: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+      - name: Upload packed artifact (尝试 2/3)
+        if: inputs.usePack == 'true' && inputs.buildStage == 'product' && steps.upload_packed_1.outcome == 'failure'
+        id: upload_packed_2
+        uses: actions/upload-artifact@v4
+        timeout-minutes: 5
+        continue-on-error: true
+        with:
+          name: ${{ steps.upload_params_packed.outputs.artifact_name }}
+          path: ${{ steps.target_parent_path.outputs.PARENT_PATH }}/target/${{ inputs.buildStage }}/release/packed/${{ inputs.packageName }}.exe
+          overwrite: true
+
+      - name: Upload packed artifact 第 2 次失败通知
+        if: inputs.usePack == 'true' && inputs.buildStage == 'product' && steps.upload_packed_2.outcome == 'failure'
+        uses: foxundermoon/feishu-action@v2
+        with:
+          url: ${{ secrets.webhookFeishu }}
+          msg_type: post
+          content: |
+            post:
+              zh_cn:
+                title: ⚠️ ${{ inputs.projectName }} Upload packed artifact 失败 (2/3)，自动重试中...
+                content:
+                - - tag: text
+                    un_escape: true
+                    text: '部署环境: ${{ inputs.buildStage }}'
+                - - tag: text
+                    text: '部署链接: '
+                  - tag: a
+                    text: github action
+                    href: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+      - name: Upload packed artifact (尝试 3/3)
+        if: inputs.usePack == 'true' && inputs.buildStage == 'product' && steps.upload_packed_2.outcome == 'failure'
+        id: upload_packed_3
+        uses: actions/upload-artifact@v4
+        timeout-minutes: 5
+        continue-on-error: true
+        with:
+          name: ${{ steps.upload_params_packed.outputs.artifact_name }}
+          path: ${{ steps.target_parent_path.outputs.PARENT_PATH }}/target/${{ inputs.buildStage }}/release/packed/${{ inputs.packageName }}.exe
+          overwrite: true
+
+      - name: Upload packed artifact 最终检查
+        if: inputs.usePack == 'true' && inputs.buildStage == 'product' && steps.upload_packed_1.outcome == 'failure' && steps.upload_packed_2.outcome == 'failure' && steps.upload_packed_3.outcome == 'failure'
+        shell: powershell
+        run: |
+          Write-Host "Upload packed artifact failed 3 times in a row"
+          exit 1
 
       - name: 构建成功通知
         if: success()

--- a/.github/workflows/rust-exe-update-template.yml
+++ b/.github/workflows/rust-exe-update-template.yml
@@ -198,7 +198,7 @@ jobs:
         if: steps.upload_1.outcome == 'failure' && steps.upload_2.outcome == 'failure' && steps.upload_3.outcome == 'failure'
         shell: powershell
         run: |
-          Write-Host "Upload artifact 连续 3 次失败"
+          Write-Host "Upload artifact failed 3 times in a row"
           exit 1
 
       - name: 设置 packed 上传参数
@@ -209,14 +209,85 @@ jobs:
           $name = '${{ inputs.packageName }}-${{ inputs.buildStage }}-${{ github.ref_name }}-${{ github.sha }}-packed.exe'
           echo "artifact_name=$name" >> $env:GITHUB_OUTPUT
 
-      - name: Upload packed artifact
+      - name: Upload packed artifact (尝试 1/3)
         if: inputs.usePack == 'true' && inputs.buildStage == 'product'
+        id: upload_packed_1
         uses: actions/upload-artifact@v4
         timeout-minutes: 5
+        continue-on-error: true
         with:
           name: ${{ steps.upload_params_packed.outputs.artifact_name }}
           path: ${{ steps.target_parent_path.outputs.PARENT_PATH }}/target/${{ inputs.buildStage }}/release/packed/${{ inputs.packageName }}.exe
           overwrite: true
+
+      - name: Upload packed artifact 第 1 次失败通知
+        if: inputs.usePack == 'true' && inputs.buildStage == 'product' && steps.upload_packed_1.outcome == 'failure'
+        uses: foxundermoon/feishu-action@v2
+        with:
+          url: ${{ secrets.webhookFeishu }}
+          msg_type: post
+          content: |
+            post:
+              zh_cn:
+                title: ⚠️ ${{ inputs.projectName }} Upload packed artifact 失败 (1/3)，自动重试中...
+                content:
+                - - tag: text
+                    un_escape: true
+                    text: '部署环境: ${{ inputs.buildStage }}'
+                - - tag: text
+                    text: '部署链接: '
+                  - tag: a
+                    text: github action
+                    href: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+      - name: Upload packed artifact (尝试 2/3)
+        if: inputs.usePack == 'true' && inputs.buildStage == 'product' && steps.upload_packed_1.outcome == 'failure'
+        id: upload_packed_2
+        uses: actions/upload-artifact@v4
+        timeout-minutes: 5
+        continue-on-error: true
+        with:
+          name: ${{ steps.upload_params_packed.outputs.artifact_name }}
+          path: ${{ steps.target_parent_path.outputs.PARENT_PATH }}/target/${{ inputs.buildStage }}/release/packed/${{ inputs.packageName }}.exe
+          overwrite: true
+
+      - name: Upload packed artifact 第 2 次失败通知
+        if: inputs.usePack == 'true' && inputs.buildStage == 'product' && steps.upload_packed_2.outcome == 'failure'
+        uses: foxundermoon/feishu-action@v2
+        with:
+          url: ${{ secrets.webhookFeishu }}
+          msg_type: post
+          content: |
+            post:
+              zh_cn:
+                title: ⚠️ ${{ inputs.projectName }} Upload packed artifact 失败 (2/3)，自动重试中...
+                content:
+                - - tag: text
+                    un_escape: true
+                    text: '部署环境: ${{ inputs.buildStage }}'
+                - - tag: text
+                    text: '部署链接: '
+                  - tag: a
+                    text: github action
+                    href: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+      - name: Upload packed artifact (尝试 3/3)
+        if: inputs.usePack == 'true' && inputs.buildStage == 'product' && steps.upload_packed_2.outcome == 'failure'
+        id: upload_packed_3
+        uses: actions/upload-artifact@v4
+        timeout-minutes: 5
+        continue-on-error: true
+        with:
+          name: ${{ steps.upload_params_packed.outputs.artifact_name }}
+          path: ${{ steps.target_parent_path.outputs.PARENT_PATH }}/target/${{ inputs.buildStage }}/release/packed/${{ inputs.packageName }}.exe
+          overwrite: true
+
+      - name: Upload packed artifact 最终检查
+        if: inputs.usePack == 'true' && inputs.buildStage == 'product' && steps.upload_packed_1.outcome == 'failure' && steps.upload_packed_2.outcome == 'failure' && steps.upload_packed_3.outcome == 'failure'
+        shell: powershell
+        run: |
+          Write-Host "Upload packed artifact failed 3 times in a row"
+          exit 1
 
       - name: 构建成功通知
         if: success()


### PR DESCRIPTION
- 将上传打包构件的步骤改为三次重试机制，每次重试都有独立的通知
- 添加了飞书通知功能，在每次上传失败时发送重试提醒
- 修正了 PowerShell 脚本中的中文错误消息为英文
- 优化了上传失败的最终检查逻辑，确保在三次都失败时正确退出
- 为上传步骤添加了 continue-on-error 配置以支持重试逻辑
- 更新了飞书通知的消息格式和内容结构