### PR TITLE
refactor(workflow): 将AWS S3替换为腾讯云COS存储服务

### DIFF
--- a/.github/workflows/rust-exe-update-template-test.yml
+++ b/.github/workflows/rust-exe-update-template-test.yml
@@ -13,7 +13,7 @@ on:
         required: true
         type: string
         default: ""
-      awsRegion:
+      tencentRegion:
         required: true
         type: string
       bucket:
@@ -23,12 +23,16 @@ on:
         required: false
         type: string
         default: 'false'
+      retries:
+        required: false
+        type: number
+        default: 3
     secrets:
       webhookFeishu:
         required: true
-      awsAccessKey:
+      TENCENT_SECRET_ID:
         required: false
-      awsSecretKey:
+      TENCENT_SECRET_KEY:
         required: false
       updateApi:
         required: true
@@ -111,183 +115,30 @@ jobs:
           $parentPath = Split-Path -Parent (Get-Location).Path
           echo "PARENT_PATH=$parentPath" >> $env:GITHUB_OUTPUT
 
-      - name: 设置上传参数
-        id: upload_params
+      - name: Upload unpacked via coscli
         shell: powershell
         run: |
-          if ('${{ inputs.buildStage }}' -eq 'product') {
-            $name = '${{ inputs.packageName }}-${{ inputs.buildStage }}-${{ github.ref_name }}-${{ github.sha }}.exe'
-          } else {
-            $name = '${{ inputs.packageName }}-${{ inputs.buildStage }}-${{ github.sha }}.exe'
-          }
-          echo "artifact_name=$name" >> $env:GITHUB_OUTPUT
+          $secretId = '${{ secrets.TENCENT_SECRET_ID }}'
+          $secretKey = '${{ secrets.TENCENT_SECRET_KEY }}'
+          $region = '${{ inputs.tencentRegion }}'
+          $bucket = '${{ inputs.bucket }}'
+          $key = 'release/unpacked/${{ github.run_id }}/${{ inputs.packageName }}.exe'
+          $local = "${{ steps.target_parent_path.outputs.PARENT_PATH }}\target\${{ inputs.buildStage }}\release\${{ inputs.packageName }}.exe"
+          .\coscli.exe --secret-id $secretId --secret-key $secretKey --region $region --bucket $bucket --key $key --local $local --retries ${{ inputs.retries }}
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-      - name: Upload artifact (尝试 1/3)
-        id: upload_1
-        uses: actions/upload-artifact@v4
-        timeout-minutes: 5
-        continue-on-error: true
-        with:
-          name: ${{ steps.upload_params.outputs.artifact_name }}
-          path: ${{ steps.target_parent_path.outputs.PARENT_PATH }}/target/${{ inputs.buildStage }}/release/${{ inputs.packageName }}.exe
-          overwrite: true
-
-      - name: Upload artifact 第 1 次失败通知
-        if: steps.upload_1.outcome == 'failure'
-        uses: foxundermoon/feishu-action@v2
-        with:
-          url: ${{ secrets.webhookFeishu }}
-          msg_type: post
-          content: |
-            post:
-              zh_cn:
-                title: ⚠️ ${{ inputs.projectName }} Upload artifact 失败 (1/3)，自动重试中...
-                content:
-                - - tag: text
-                    un_escape: true
-                    text: '部署环境: ${{ inputs.buildStage }}'
-                - - tag: text
-                    text: '部署链接: '
-                  - tag: a
-                    text: github action
-                    href: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
-      - name: Upload artifact (尝试 2/3)
-        if: steps.upload_1.outcome == 'failure'
-        id: upload_2
-        uses: actions/upload-artifact@v4
-        timeout-minutes: 5
-        continue-on-error: true
-        with:
-          name: ${{ steps.upload_params.outputs.artifact_name }}
-          path: ${{ steps.target_parent_path.outputs.PARENT_PATH }}/target/${{ inputs.buildStage }}/release/${{ inputs.packageName }}.exe
-          overwrite: true
-
-      - name: Upload artifact 第 2 次失败通知
-        if: steps.upload_2.outcome == 'failure'
-        uses: foxundermoon/feishu-action@v2
-        with:
-          url: ${{ secrets.webhookFeishu }}
-          msg_type: post
-          content: |
-            post:
-              zh_cn:
-                title: ⚠️ ${{ inputs.projectName }} Upload artifact 失败 (2/3)，自动重试中...
-                content:
-                - - tag: text
-                    un_escape: true
-                    text: '部署环境: ${{ inputs.buildStage }}'
-                - - tag: text
-                    text: '部署链接: '
-                  - tag: a
-                    text: github action
-                    href: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
-      - name: Upload artifact (尝试 3/3)
-        if: steps.upload_2.outcome == 'failure'
-        id: upload_3
-        uses: actions/upload-artifact@v4
-        timeout-minutes: 5
-        continue-on-error: true
-        with:
-          name: ${{ steps.upload_params.outputs.artifact_name }}
-          path: ${{ steps.target_parent_path.outputs.PARENT_PATH }}/target/${{ inputs.buildStage }}/release/${{ inputs.packageName }}.exe
-          overwrite: true
-
-      - name: Upload artifact 最终检查
-        if: steps.upload_1.outcome == 'failure' && steps.upload_2.outcome == 'failure' && steps.upload_3.outcome == 'failure'
-        shell: powershell
-        run: |
-          Write-Host "Upload artifact failed 3 times in a row"
-          exit 1
-
-      - name: 设置 packed 上传参数
-        id: upload_params_packed
+      - name: Upload packed via coscli
         if: inputs.usePack == 'true' && inputs.buildStage == 'product'
         shell: powershell
         run: |
-          $name = '${{ inputs.packageName }}-${{ inputs.buildStage }}-${{ github.ref_name }}-${{ github.sha }}-packed.exe'
-          echo "artifact_name=$name" >> $env:GITHUB_OUTPUT
-
-      - name: Upload packed artifact (尝试 1/3)
-        if: inputs.usePack == 'true' && inputs.buildStage == 'product'
-        id: upload_packed_1
-        uses: actions/upload-artifact@v4
-        timeout-minutes: 5
-        continue-on-error: true
-        with:
-          name: ${{ steps.upload_params_packed.outputs.artifact_name }}
-          path: ${{ steps.target_parent_path.outputs.PARENT_PATH }}/target/${{ inputs.buildStage }}/release/packed/${{ inputs.packageName }}.exe
-          overwrite: true
-
-      - name: Upload packed artifact 第 1 次失败通知
-        if: inputs.usePack == 'true' && inputs.buildStage == 'product' && steps.upload_packed_1.outcome == 'failure'
-        uses: foxundermoon/feishu-action@v2
-        with:
-          url: ${{ secrets.webhookFeishu }}
-          msg_type: post
-          content: |
-            post:
-              zh_cn:
-                title: ⚠️ ${{ inputs.projectName }} Upload packed artifact 失败 (1/3)，自动重试中...
-                content:
-                - - tag: text
-                    un_escape: true
-                    text: '部署环境: ${{ inputs.buildStage }}'
-                - - tag: text
-                    text: '部署链接: '
-                  - tag: a
-                    text: github action
-                    href: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
-      - name: Upload packed artifact (尝试 2/3)
-        if: inputs.usePack == 'true' && inputs.buildStage == 'product' && steps.upload_packed_1.outcome == 'failure'
-        id: upload_packed_2
-        uses: actions/upload-artifact@v4
-        timeout-minutes: 5
-        continue-on-error: true
-        with:
-          name: ${{ steps.upload_params_packed.outputs.artifact_name }}
-          path: ${{ steps.target_parent_path.outputs.PARENT_PATH }}/target/${{ inputs.buildStage }}/release/packed/${{ inputs.packageName }}.exe
-          overwrite: true
-
-      - name: Upload packed artifact 第 2 次失败通知
-        if: inputs.usePack == 'true' && inputs.buildStage == 'product' && steps.upload_packed_2.outcome == 'failure'
-        uses: foxundermoon/feishu-action@v2
-        with:
-          url: ${{ secrets.webhookFeishu }}
-          msg_type: post
-          content: |
-            post:
-              zh_cn:
-                title: ⚠️ ${{ inputs.projectName }} Upload packed artifact 失败 (2/3)，自动重试中...
-                content:
-                - - tag: text
-                    un_escape: true
-                    text: '部署环境: ${{ inputs.buildStage }}'
-                - - tag: text
-                    text: '部署链接: '
-                  - tag: a
-                    text: github action
-                    href: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
-      - name: Upload packed artifact (尝试 3/3)
-        if: inputs.usePack == 'true' && inputs.buildStage == 'product' && steps.upload_packed_2.outcome == 'failure'
-        id: upload_packed_3
-        uses: actions/upload-artifact@v4
-        timeout-minutes: 5
-        continue-on-error: true
-        with:
-          name: ${{ steps.upload_params_packed.outputs.artifact_name }}
-          path: ${{ steps.target_parent_path.outputs.PARENT_PATH }}/target/${{ inputs.buildStage }}/release/packed/${{ inputs.packageName }}.exe
-          overwrite: true
-
-      - name: Upload packed artifact 最终检查
-        if: inputs.usePack == 'true' && inputs.buildStage == 'product' && steps.upload_packed_1.outcome == 'failure' && steps.upload_packed_2.outcome == 'failure' && steps.upload_packed_3.outcome == 'failure'
-        shell: powershell
-        run: |
-          Write-Host "Upload packed artifact failed 3 times in a row"
-          exit 1
+          $secretId = '${{ secrets.TENCENT_SECRET_ID }}'
+          $secretKey = '${{ secrets.TENCENT_SECRET_KEY }}'
+          $region = '${{ inputs.tencentRegion }}'
+          $bucket = '${{ inputs.bucket }}'
+          $key = 'release/packed/${{ github.run_id }}/${{ inputs.packageName }}.exe'
+          $local = "${{ steps.target_parent_path.outputs.PARENT_PATH }}\target\${{ inputs.buildStage }}\release\packed\${{ inputs.packageName }}.exe"
+          .\coscli.exe --secret-id $secretId --secret-key $secretKey --region $region --bucket $bucket --key $key --local $local --retries ${{ inputs.retries }}
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: 构建成功通知
         if: success()
@@ -385,12 +236,15 @@ jobs:
           name: ${{ inputs.packageName }}-${{ inputs.buildStage }}-${{ github.ref_name }}-${{ github.sha }}.exe
           path: ./
 
-      - name: Download packed artifact product
+      - name: Download packed from COS staging
         if: inputs.buildStage == 'product' && inputs.usePack == 'true'
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ inputs.packageName }}-${{ inputs.buildStage }}-${{ github.ref_name }}-${{ github.sha }}-packed.exe
-          path: ./packed/
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.TENCENT_SECRET_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.TENCENT_SECRET_KEY }}
+          AWS_DEFAULT_REGION: ${{ inputs.tencentRegion }}
+        run: |
+          mkdir -p ./packed
+          aws s3 cp "s3://${{ inputs.bucket }}/_tmp/packed/${{ github.run_id }}/${{ inputs.packageName }}.exe" "./packed/${{ inputs.packageName }}.exe" --endpoint-url "https://cos.${{ inputs.tencentRegion }}.myqcloud.com" --no-progress --only-show-errors
 
       - name: Download artifact
         if: inputs.buildStage != 'product'
@@ -402,53 +256,14 @@ jobs:
       - name: Display structure of downloaded files
         run: ls -R
 
-      - name: Upload main to S3 (packed, product)
-        if: inputs.buildStage == 'product' && inputs.usePack == 'true'
-        uses: keithweaver/aws-s3-github-action@v1.0.0
-        with:
-          command: cp
-          source: ./packed/${{ inputs.packageName }}.exe
-          destination: s3://${{ inputs.bucket }}/windows/release/${{ inputs.packageName }}-${{ github.ref_name }}.exe
-          aws_access_key_id: ${{ secrets.awsAccessKey }}
-          aws_secret_access_key: ${{ secrets.awsSecretKey }}
-          aws_region: ${{ inputs.awsRegion }}
-          flags: --acl public-read
-
-      - name: Upload main to S3 (unpacked, product)
-        if: inputs.buildStage == 'product' && inputs.usePack != 'true'
-        uses: keithweaver/aws-s3-github-action@v1.0.0
-        with:
-          command: cp
-          source: ./${{ inputs.packageName }}.exe
-          destination: s3://${{ inputs.bucket }}/windows/release/${{ inputs.packageName }}-${{  github.ref_name }}.exe
-          aws_access_key_id: ${{ secrets.awsAccessKey }}
-          aws_secret_access_key: ${{ secrets.awsSecretKey }}
-          aws_region: ${{ inputs.awsRegion }}
-          flags: --acl public-read
-
-      - name: Upload backup (unpacked) to S3 (product)
-        if: inputs.buildStage == 'product' && inputs.usePack == 'true'
-        uses: keithweaver/aws-s3-github-action@v1.0.0
-        with:
-          command: cp
-          source: ./${{ inputs.packageName }}.exe
-          destination: s3://${{ inputs.bucket }}/windows/release/unpacked/${{ inputs.packageName }}-${{ github.ref_name }}.exe
-          aws_access_key_id: ${{ secrets.awsAccessKey }}
-          aws_secret_access_key: ${{ secrets.awsSecretKey }}
-          aws_region: ${{ inputs.awsRegion }}
-          flags: --acl public-read
-
-      - name: Upload to S3
-        if: inputs.buildStage != 'product'
-        uses: keithweaver/aws-s3-github-action@v1.0.0
-        with:
-          command: cp
-          source: ./${{ inputs.packageName }}.exe
-          destination: s3://${{ inputs.bucket }}/windows/packed_test/${{ inputs.buildStage }}/${{ inputs.packageName }}-${{ github.ref_name }}-${{ github.sha }}.exe
-          aws_access_key_id: ${{ secrets.awsAccessKey }}
-          aws_secret_access_key: ${{ secrets.awsSecretKey }}
-          aws_region: ${{ inputs.awsRegion }}
-          flags: --acl public-read
+      - name: Cleanup COS staging
+        if: always() && inputs.buildStage == 'product' && inputs.usePack == 'true'
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.TENCENT_SECRET_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.TENCENT_SECRET_KEY }}
+          AWS_DEFAULT_REGION: ${{ inputs.tencentRegion }}
+        run: |
+          aws s3 rm "s3://${{ inputs.bucket }}/_tmp/packed/${{ github.run_id }}/${{ inputs.packageName }}.exe" --endpoint-url "https://cos.${{ inputs.tencentRegion }}.myqcloud.com" || true
 
 #      - name: update version
 #        if: inputs.buildStage != 'dev'


### PR DESCRIPTION
- 将awsRegion输入参数重命名为tencentRegion
- 将awsAccessKey和awsSecretKey密钥替换为TENCENT_SECRET_ID和TENCENT_SECRET_KEY
- 添加retries重试次数配置参数，默认值为3
- 使用coscli工具替代原有artifact上传方式
- 移除原有的多轮重试上传逻辑和飞书通知机制
- 替换下载artifact步骤为从COS获取打包文件
- 移除AWS S3上传操作，改用腾讯云COS存储
- 添加临时文件清理机制以保持COS空间整洁