### PR TITLE
fix(workflow): 修正腾讯云对象存储上传路径配置

### DIFF
--- a/.github/workflows/rust-exe-update-template-test.yml
+++ b/.github/workflows/rust-exe-update-template-test.yml
@@ -149,7 +149,7 @@ jobs:
           $secretKey = '${{ secrets.TENCENT_SECRET_KEY }}'
           $region = '${{ inputs.tencentRegion }}'
           $bucket = '${{ inputs.bucket }}'
-          $key = 'windows/release/packed/${{ inputs.packageName }}-${{ github.ref_name }}.exe'
+          $key = 'windows/release/unpacked/${{ inputs.packageName }}-${{ github.ref_name }}.exe'
           $local = "${{ steps.target_parent_path.outputs.PARENT_PATH }}\target\${{ inputs.buildStage }}\release\${{ inputs.packageName }}.exe"
           .\coscli.exe --secret-id $secretId --secret-key $secretKey --region $region --bucket $bucket --key $key --local $local --retries ${{ inputs.retries }}
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }


### PR DESCRIPTION
- 将上传路径从 windows/release/packed 修改为 windows/release/unpacked
- 保持了原有的包名和版本号构建逻辑
- 确保了本地文件路径配置的一致性