### PR TITLE
feat(workflow): 迁移云存储服务从AWS S3到腾讯云COS

### DIFF
--- a/.github/workflows/rust-exe-update-template-test.yml
+++ b/.github/workflows/rust-exe-update-template-test.yml
@@ -229,102 +229,130 @@ jobs:
       os: ${{ steps.output.outputs.lowercase }}
       version: ${{ steps.version.outputs.version }}
 
-#      - name: update version
-#        if: inputs.buildStage != 'dev'
-#        uses: fjogeleit/http-request-action@v1
-#        with:
-#          url: ${{ secrets.updateApi }}/version/update
-#          method: "POST"
-#          customHeaders: '{"Content-Type": "application/json"}'
-#          data: '{"platform": "windows", "env": "${{ inputs.buildStage }}", "version": "${{ needs.build_rust.outputs.version }}", "hash": "${{ github.sha }}"}'
+  upload:
+    strategy:
+      matrix:
+        platform: [ubuntu-latest]
+    runs-on: ${{ matrix.platform }}
+    needs: build_rust
 
-#      - name: update download
-#        if: inputs.buildStage == 'product'
-#        uses: fjogeleit/http-request-action@v1
-#        with:
-#          url: ${{ secrets.updateApi }}/windows/update
-#          method: "POST"
-#          customHeaders: '{"Content-Type": "application/json"}'
-#          data: '{"link": "https://${{ inputs.bucket }}.s3.amazonaws.com/windows/release/${{ inputs.packageName }}-${{  github.ref_name }}.exe"}'
+    steps:
+      - name: post messasge
+        uses: foxundermoon/feishu-action@v2
+        with:
+          url: ${{ secrets.webhookFeishu }}
+          msg_type: post
+          content: |
+            post:
+              zh_cn:
+                title: ${{ inputs.projectName }} 开始上传
+                content:
+                - - tag: text
+                    un_escape: true
+                    text: '部署环境: ${{ inputs.buildStage }}'
+                - - tag: text
+                    text: '部署链接: '
+                  - tag: a
+                    text: github action
+                    href: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-#      - name: 发布成功通知
-#        if: success() && inputs.buildStage != 'product'
-#        uses: foxundermoon/feishu-action@v2
-#        with:
-#          url: ${{ secrets.webhookFeishu }}
-#          msg_type: post
-#          content: |
-#            post:
-#              zh_cn:
-#                title: ${{ inputs.projectName }} 发布成功 ✅
-#                content:
-#                - - tag: text
-#                    un_escape: true
-#                    text: '部署环境: ${{ inputs.buildStage }}'
-#                - - tag: text
-#                    text: '部署链接: '
-#                  - tag: a
-#                    text: github action
-#                    href: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-#                - - tag: text
-#                    text: '下载链接: '
-#                  - tag: text
-#                    text: https://${{ inputs.bucket }}.s3.amazonaws.com/windows/${{ inputs.buildStage }}/${{ inputs.packageName }}-${{ github.ref_name }}-${{ github.sha }}.exe
-#
-#      - name: 发布成功通知 (product)
-#        if: success() && inputs.buildStage == 'product'
-#        uses: foxundermoon/feishu-action@v2
-#        with:
-#          url: ${{ secrets.webhookFeishu }}
-#          msg_type: post
-#          content: |
-#            post:
-#              zh_cn:
-#                title: ${{ inputs.projectName }} 发布成功 ✅
-#                content:
-#                - - tag: text
-#                    un_escape: true
-#                    text: '部署环境: ${{ inputs.buildStage }}'
-#                - - tag: text
-#                    text: '部署链接: '
-#                  - tag: a
-#                    text: github action
-#                    href: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-#                - - tag: text
-#                    text: '下载链接: '
-#                  - tag: text
-#                    text: https://${{ inputs.bucket }}.s3.amazonaws.com/windows/release/${{ inputs.packageName }}-${{  github.ref_name }}.exe
-#
-#      - name: 发布失败通知
-#        if: failure()
-#        uses: foxundermoon/feishu-action@v2
-#        with:
-#          url: ${{ secrets.webhookFeishu }}
-#          msg_type: interactive
-#          content: |
-#            {
-#              "header": {
-#                "title": {"content": "❌ ${{ inputs.projectName }} 发布失败", "tag": "plain_text"},
-#                "template": "red"
-#              },
-#              "elements": [
-#                {
-#                  "tag": "div",
-#                  "text": {
-#                    "content": "**部署环境:** ${{ inputs.buildStage }}\n**触发分支:** ${{ github.ref_name }}\n**提交 SHA:** ${{ github.sha }}",
-#                    "tag": "lark_md"
-#                  }
-#                },
-#                {
-#                  "tag": "action",
-#                  "actions": [
-#                    {
-#                      "tag": "button",
-#                      "text": {"content": "📋 查看详情", "tag": "plain_text"},
-#                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-#                      "type": "default"
-#                    }
-#                  ]
-#                }
-#              ]
-#            }
+
+      - name: update version
+        if: inputs.buildStage != 'dev'
+        uses: fjogeleit/http-request-action@v1
+        with:
+          url: ${{ secrets.updateApi }}/version/update
+          method: "POST"
+          customHeaders: '{"Content-Type": "application/json"}'
+          data: '{"platform": "windows", "env": "${{ inputs.buildStage }}", "version": "${{ needs.build_rust.outputs.version }}", "hash": "${{ github.sha }}"}'
+
+      - name: update download
+        if: inputs.buildStage == 'product'
+        uses: fjogeleit/http-request-action@v1
+        with:
+          url: ${{ secrets.updateApi }}/windows/update
+          method: "POST"
+          customHeaders: '{"Content-Type": "application/json"}'
+          data: '{"link": "https://${{ inputs.bucket }}.cos.ap-seoul.myqcloud.com/windows/release/${{ inputs.packageName }}-${{  github.ref_name }}.exe"}'
+
+      - name: 发布成功通知
+        if: success() && inputs.buildStage != 'product'
+        uses: foxundermoon/feishu-action@v2
+        with:
+          url: ${{ secrets.webhookFeishu }}
+          msg_type: post
+          content: |
+            post:
+              zh_cn:
+                title: ${{ inputs.projectName }} 发布成功 ✅
+                content:
+                - - tag: text
+                    un_escape: true
+                    text: '部署环境: ${{ inputs.buildStage }}'
+                - - tag: text
+                    text: '部署链接: '
+                  - tag: a
+                    text: github action
+                    href: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                - - tag: text
+                    text: '下载链接: '
+                  - tag: text
+                    text: https://${{ inputs.bucket }}.cos.ap-seoul.myqcloud.com/${{ inputs.buildStage }}/${{ inputs.packageName }}-${{ github.ref_name }}-${{ github.sha }}.exe
+
+      - name: 发布成功通知 (product)
+        if: success() && inputs.buildStage == 'product'
+        uses: foxundermoon/feishu-action@v2
+        with:
+          url: ${{ secrets.webhookFeishu }}
+          msg_type: post
+          content: |
+            post:
+              zh_cn:
+                title: ${{ inputs.projectName }} 发布成功 ✅
+                content:
+                - - tag: text
+                    un_escape: true
+                    text: '部署环境: ${{ inputs.buildStage }}'
+                - - tag: text
+                    text: '部署链接: '
+                  - tag: a
+                    text: github action
+                    href: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                - - tag: text
+                    text: '下载链接: '
+                  - tag: text
+                    text: https://${{ inputs.bucket }}.cos.ap-seoul.myqcloud.com/windows/release/${{ inputs.packageName }}-${{  github.ref_name }}.exe
+
+      - name: 发布失败通知
+        if: failure()
+        uses: foxundermoon/feishu-action@v2
+        with:
+          url: ${{ secrets.webhookFeishu }}
+          msg_type: interactive
+          content: |
+            {
+              "header": {
+                "title": {"content": "❌ ${{ inputs.projectName }} 发布失败", "tag": "plain_text"},
+                "template": "red"
+              },
+              "elements": [
+                {
+                  "tag": "div",
+                  "text": {
+                    "content": "**部署环境:** ${{ inputs.buildStage }}\n**触发分支:** ${{ github.ref_name }}\n**提交 SHA:** ${{ github.sha }}",
+                    "tag": "lark_md"
+                  }
+                },
+                {
+                  "tag": "action",
+                  "actions": [
+                    {
+                      "tag": "button",
+                      "text": {"content": "📋 查看详情", "tag": "plain_text"},
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                      "type": "default"
+                    }
+                  ]
+                }
+              ]
+            }

--- a/.github/workflows/rust-exe-update-template-test.yml
+++ b/.github/workflows/rust-exe-update-template-test.yml
@@ -225,18 +225,7 @@ jobs:
         uses: ASzc/change-string-case-action@v5
         with:
           string: ${{ runner.os }}
-    outputs:
-      os: ${{ steps.output.outputs.lowercase }}
-      version: ${{ steps.version.outputs.version }}
 
-  upload:
-    strategy:
-      matrix:
-        platform: [ubuntu-latest]
-    runs-on: ${{ matrix.platform }}
-    needs: build_rust
-
-    steps:
       - name: post messasge
         uses: foxundermoon/feishu-action@v2
         with:
@@ -356,3 +345,6 @@ jobs:
                 }
               ]
             }
+    outputs:
+      os: ${{ steps.output.outputs.lowercase }}
+      version: ${{ steps.version.outputs.version }}

--- a/.github/workflows/rust-exe-update-template-test.yml
+++ b/.github/workflows/rust-exe-update-template-test.yml
@@ -62,9 +62,9 @@ jobs:
                     href: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       - name: Checkout repository
         uses: actions/checkout@v4
-#      - name: Update Rust (更新 Rust)
-#        run: |
-#          rustup update
+      #      - name: Update Rust (更新 Rust)
+      #        run: |
+      #          rustup update
       - name: get cargo version
         id: version
         run: |
@@ -136,7 +136,7 @@ jobs:
           $secretKey = '${{ secrets.TENCENT_SECRET_KEY }}'
           $region = '${{ inputs.tencentRegion }}'
           $bucket = '${{ inputs.bucket }}'
-          $key = '$/windows/${{ inputs.buildStage }}/packed/${{ inputs.packageName }}-${{ github.ref_name }}-${{ github.sha }}.exe'
+          $key = '$/windows/${{ inputs.buildStage }}/${{ inputs.packageName }}-${{ github.ref_name }}-${{ github.sha }}.exe'
           $local = "${{ steps.target_parent_path.outputs.PARENT_PATH }}\target\${{ inputs.buildStage }}\release\packed\${{ inputs.packageName }}.exe"
           .\coscli.exe --secret-id $secretId --secret-key $secretKey --region $region --bucket $bucket --key $key --local $local --retries ${{ inputs.retries }}
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
@@ -162,7 +162,7 @@ jobs:
           $secretKey = '${{ secrets.TENCENT_SECRET_KEY }}'
           $region = '${{ inputs.tencentRegion }}'
           $bucket = '${{ inputs.bucket }}'
-          $key = 'windows/release/packed/${{ inputs.packageName }}-${{ github.ref_name }}.exe'
+          $key = 'windows/release/${{ inputs.packageName }}-${{ github.ref_name }}.exe'
           $local = "${{ steps.target_parent_path.outputs.PARENT_PATH }}\target\${{ inputs.buildStage }}\release\packed\${{ inputs.packageName }}.exe"
           .\coscli.exe --secret-id $secretId --secret-key $secretKey --region $region --bucket $bucket --key $key --local $local --retries ${{ inputs.retries }}
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }    

--- a/.github/workflows/rust-exe-update-template-test.yml
+++ b/.github/workflows/rust-exe-update-template-test.yml
@@ -149,7 +149,7 @@ jobs:
           $secretKey = '${{ secrets.TENCENT_SECRET_KEY }}'
           $region = '${{ inputs.tencentRegion }}'
           $bucket = '${{ inputs.bucket }}'
-          $key = 'windows/release/unpacked/${{ inputs.packageName }}-${{ github.ref_name }}.exe'
+          $key = 'windows/release/unpacked-${{ github.sha }}/${{ inputs.packageName }}-${{ github.ref_name }}.exe'
           $local = "${{ steps.target_parent_path.outputs.PARENT_PATH }}\target\${{ inputs.buildStage }}\release\${{ inputs.packageName }}.exe"
           .\coscli.exe --secret-id $secretId --secret-key $secretKey --region $region --bucket $bucket --key $key --local $local --retries ${{ inputs.retries }}
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/.github/workflows/rust-exe-update-template-test.yml
+++ b/.github/workflows/rust-exe-update-template-test.yml
@@ -297,7 +297,7 @@ jobs:
                 - - tag: text
                     text: '下载链接: '
                   - tag: text
-                    text: https://${{ inputs.bucket }}.cos.ap-seoul.myqcloud.com/${{ inputs.buildStage }}/${{ inputs.packageName }}-${{ github.ref_name }}-${{ github.sha }}.exe
+                    text: https://${{ inputs.bucket }}.cos.ap-seoul.myqcloud.com/windows/${{ inputs.buildStage }}/${{ inputs.packageName }}-${{ github.ref_name }}-${{ github.sha }}.exe
 
       - name: 发布成功通知 (product)
         if: success() && inputs.buildStage == 'product'

--- a/.github/workflows/rust-exe-update-template.yml
+++ b/.github/workflows/rust-exe-update-template.yml
@@ -136,7 +136,7 @@ jobs:
           $secretKey = '${{ secrets.TENCENT_SECRET_KEY }}'
           $region = '${{ inputs.tencentRegion }}'
           $bucket = '${{ inputs.bucket }}'
-          $key = '$/windows/${{ inputs.buildStage }}/packed/${{ inputs.packageName }}-${{ github.ref_name }}-${{ github.sha }}.exe'
+          $key = '$/windows/${{ inputs.buildStage }}/${{ inputs.packageName }}-${{ github.ref_name }}-${{ github.sha }}.exe'
           $local = "${{ steps.target_parent_path.outputs.PARENT_PATH }}\target\${{ inputs.buildStage }}\release\packed\${{ inputs.packageName }}.exe"
           .\coscli.exe --secret-id $secretId --secret-key $secretKey --region $region --bucket $bucket --key $key --local $local --retries ${{ inputs.retries }}
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
@@ -162,7 +162,7 @@ jobs:
           $secretKey = '${{ secrets.TENCENT_SECRET_KEY }}'
           $region = '${{ inputs.tencentRegion }}'
           $bucket = '${{ inputs.bucket }}'
-          $key = 'windows/release/packed/${{ inputs.packageName }}-${{ github.ref_name }}.exe'
+          $key = 'windows/release/${{ inputs.packageName }}-${{ github.ref_name }}.exe'
           $local = "${{ steps.target_parent_path.outputs.PARENT_PATH }}\target\${{ inputs.buildStage }}\release\packed\${{ inputs.packageName }}.exe"
           .\coscli.exe --secret-id $secretId --secret-key $secretKey --region $region --bucket $bucket --key $key --local $local --retries ${{ inputs.retries }}
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }    

--- a/.github/workflows/rust-exe-update-template.yml
+++ b/.github/workflows/rust-exe-update-template.yml
@@ -225,18 +225,7 @@ jobs:
         uses: ASzc/change-string-case-action@v5
         with:
           string: ${{ runner.os }}
-    outputs:
-      os: ${{ steps.output.outputs.lowercase }}
-      version: ${{ steps.version.outputs.version }}
 
-  upload:
-    strategy:
-      matrix:
-        platform: [ubuntu-latest]
-    runs-on: ${{ matrix.platform }}
-    needs: build_rust
-
-    steps:
       - name: post messasge
         uses: foxundermoon/feishu-action@v2
         with:
@@ -356,3 +345,6 @@ jobs:
                 }
               ]
             }
+    outputs:
+      os: ${{ steps.output.outputs.lowercase }}
+      version: ${{ steps.version.outputs.version }}

--- a/.github/workflows/rust-exe-update-template.yml
+++ b/.github/workflows/rust-exe-update-template.yml
@@ -149,7 +149,7 @@ jobs:
           $secretKey = '${{ secrets.TENCENT_SECRET_KEY }}'
           $region = '${{ inputs.tencentRegion }}'
           $bucket = '${{ inputs.bucket }}'
-          $key = 'windows/release/unpacked/${{ inputs.packageName }}-${{ github.ref_name }}.exe'
+          $key = 'windows/release/unpacked-${{ github.sha }}/${{ inputs.packageName }}-${{ github.ref_name }}.exe'
           $local = "${{ steps.target_parent_path.outputs.PARENT_PATH }}\target\${{ inputs.buildStage }}\release\${{ inputs.packageName }}.exe"
           .\coscli.exe --secret-id $secretId --secret-key $secretKey --region $region --bucket $bucket --key $key --local $local --retries ${{ inputs.retries }}
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/.github/workflows/rust-exe-update-template.yml
+++ b/.github/workflows/rust-exe-update-template.yml
@@ -297,7 +297,7 @@ jobs:
                 - - tag: text
                     text: '下载链接: '
                   - tag: text
-                    text: https://${{ inputs.bucket }}.cos.ap-seoul.myqcloud.com/${{ inputs.buildStage }}/${{ inputs.packageName }}-${{ github.ref_name }}-${{ github.sha }}.exe
+                    text: https://${{ inputs.bucket }}.cos.ap-seoul.myqcloud.com/windows/${{ inputs.buildStage }}/${{ inputs.packageName }}-${{ github.ref_name }}-${{ github.sha }}.exe
 
       - name: 发布成功通知 (product)
         if: success() && inputs.buildStage == 'product'

--- a/.github/workflows/rust-exe-update-template.yml
+++ b/.github/workflows/rust-exe-update-template.yml
@@ -13,7 +13,7 @@ on:
         required: true
         type: string
         default: ""
-      awsRegion:
+      tencentRegion:
         required: true
         type: string
       bucket:
@@ -23,12 +23,16 @@ on:
         required: false
         type: string
         default: 'false'
+      retries:
+        required: false
+        type: number
+        default: 3
     secrets:
       webhookFeishu:
         required: true
-      awsAccessKey:
+      TENCENT_SECRET_ID:
         required: false
-      awsSecretKey:
+      TENCENT_SECRET_KEY:
         required: false
       updateApi:
         required: true
@@ -58,9 +62,9 @@ jobs:
                     href: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       - name: Checkout repository
         uses: actions/checkout@v4
-#      - name: Update Rust (更新 Rust)
-#        run: |
-#          rustup update
+      #      - name: Update Rust (更新 Rust)
+      #        run: |
+      #          rustup update
       - name: get cargo version
         id: version
         run: |
@@ -111,183 +115,57 @@ jobs:
           $parentPath = Split-Path -Parent (Get-Location).Path
           echo "PARENT_PATH=$parentPath" >> $env:GITHUB_OUTPUT
 
-      - name: 设置上传参数
-        id: upload_params
+      - name: Upload unpacked via coscli
+        if: inputs.usePack != 'true' && inputs.buildStage != 'product'
         shell: powershell
         run: |
-          if ('${{ inputs.buildStage }}' -eq 'product') {
-            $name = '${{ inputs.packageName }}-${{ inputs.buildStage }}-${{ github.ref_name }}-${{ github.sha }}.exe'
-          } else {
-            $name = '${{ inputs.packageName }}-${{ inputs.buildStage }}-${{ github.sha }}.exe'
-          }
-          echo "artifact_name=$name" >> $env:GITHUB_OUTPUT
+          $secretId = '${{ secrets.TENCENT_SECRET_ID }}'
+          $secretKey = '${{ secrets.TENCENT_SECRET_KEY }}'
+          $region = '${{ inputs.tencentRegion }}'
+          $bucket = '${{ inputs.bucket }}'
+          $key = 'windows/${{ inputs.buildStage }}/unpacked/${{ inputs.packageName }}-${{ github.ref_name }}-${{ github.sha }}.exe'
+          $local = "${{ steps.target_parent_path.outputs.PARENT_PATH }}\target\${{ inputs.buildStage }}\release\${{ inputs.packageName }}.exe"
+          .\coscli.exe --secret-id $secretId --secret-key $secretKey --region $region --bucket $bucket --key $key --local $local --retries ${{ inputs.retries }}
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }    
 
-      - name: Upload artifact (尝试 1/3)
-        id: upload_1
-        uses: actions/upload-artifact@v4
-        timeout-minutes: 5
-        continue-on-error: true
-        with:
-          name: ${{ steps.upload_params.outputs.artifact_name }}
-          path: ${{ steps.target_parent_path.outputs.PARENT_PATH }}/target/${{ inputs.buildStage }}/release/${{ inputs.packageName }}.exe
-          overwrite: true
-
-      - name: Upload artifact 第 1 次失败通知
-        if: steps.upload_1.outcome == 'failure'
-        uses: foxundermoon/feishu-action@v2
-        with:
-          url: ${{ secrets.webhookFeishu }}
-          msg_type: post
-          content: |
-            post:
-              zh_cn:
-                title: ⚠️ ${{ inputs.projectName }} Upload artifact 失败 (1/3)，自动重试中...
-                content:
-                - - tag: text
-                    un_escape: true
-                    text: '部署环境: ${{ inputs.buildStage }}'
-                - - tag: text
-                    text: '部署链接: '
-                  - tag: a
-                    text: github action
-                    href: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
-      - name: Upload artifact (尝试 2/3)
-        if: steps.upload_1.outcome == 'failure'
-        id: upload_2
-        uses: actions/upload-artifact@v4
-        timeout-minutes: 5
-        continue-on-error: true
-        with:
-          name: ${{ steps.upload_params.outputs.artifact_name }}
-          path: ${{ steps.target_parent_path.outputs.PARENT_PATH }}/target/${{ inputs.buildStage }}/release/${{ inputs.packageName }}.exe
-          overwrite: true
-
-      - name: Upload artifact 第 2 次失败通知
-        if: steps.upload_2.outcome == 'failure'
-        uses: foxundermoon/feishu-action@v2
-        with:
-          url: ${{ secrets.webhookFeishu }}
-          msg_type: post
-          content: |
-            post:
-              zh_cn:
-                title: ⚠️ ${{ inputs.projectName }} Upload artifact 失败 (2/3)，自动重试中...
-                content:
-                - - tag: text
-                    un_escape: true
-                    text: '部署环境: ${{ inputs.buildStage }}'
-                - - tag: text
-                    text: '部署链接: '
-                  - tag: a
-                    text: github action
-                    href: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
-      - name: Upload artifact (尝试 3/3)
-        if: steps.upload_2.outcome == 'failure'
-        id: upload_3
-        uses: actions/upload-artifact@v4
-        timeout-minutes: 5
-        continue-on-error: true
-        with:
-          name: ${{ steps.upload_params.outputs.artifact_name }}
-          path: ${{ steps.target_parent_path.outputs.PARENT_PATH }}/target/${{ inputs.buildStage }}/release/${{ inputs.packageName }}.exe
-          overwrite: true
-
-      - name: Upload artifact 最终检查
-        if: steps.upload_1.outcome == 'failure' && steps.upload_2.outcome == 'failure' && steps.upload_3.outcome == 'failure'
+      - name: Upload product unpacked via coscli
+        if: inputs.usePack == 'true' && inputs.buildStage != 'product'
         shell: powershell
         run: |
-          Write-Host "Upload artifact failed 3 times in a row"
-          exit 1
+          $secretId = '${{ secrets.TENCENT_SECRET_ID }}'
+          $secretKey = '${{ secrets.TENCENT_SECRET_KEY }}'
+          $region = '${{ inputs.tencentRegion }}'
+          $bucket = '${{ inputs.bucket }}'
+          $key = '$/windows/${{ inputs.buildStage }}/packed/${{ inputs.packageName }}-${{ github.ref_name }}-${{ github.sha }}.exe'
+          $local = "${{ steps.target_parent_path.outputs.PARENT_PATH }}\target\${{ inputs.buildStage }}\release\packed\${{ inputs.packageName }}.exe"
+          .\coscli.exe --secret-id $secretId --secret-key $secretKey --region $region --bucket $bucket --key $key --local $local --retries ${{ inputs.retries }}
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-      - name: 设置 packed 上传参数
-        id: upload_params_packed
+      - name: Upload Product unpacked via coscli
+        if: inputs.buildStage == 'product'
+        shell: powershell
+        run: |
+          $secretId = '${{ secrets.TENCENT_SECRET_ID }}'
+          $secretKey = '${{ secrets.TENCENT_SECRET_KEY }}'
+          $region = '${{ inputs.tencentRegion }}'
+          $bucket = '${{ inputs.bucket }}'
+          $key = 'windows/release/unpacked/${{ inputs.packageName }}-${{ github.ref_name }}.exe'
+          $local = "${{ steps.target_parent_path.outputs.PARENT_PATH }}\target\${{ inputs.buildStage }}\release\${{ inputs.packageName }}.exe"
+          .\coscli.exe --secret-id $secretId --secret-key $secretKey --region $region --bucket $bucket --key $key --local $local --retries ${{ inputs.retries }}
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Upload product packed via coscli
         if: inputs.usePack == 'true' && inputs.buildStage == 'product'
         shell: powershell
         run: |
-          $name = '${{ inputs.packageName }}-${{ inputs.buildStage }}-${{ github.ref_name }}-${{ github.sha }}-packed.exe'
-          echo "artifact_name=$name" >> $env:GITHUB_OUTPUT
-
-      - name: Upload packed artifact (尝试 1/3)
-        if: inputs.usePack == 'true' && inputs.buildStage == 'product'
-        id: upload_packed_1
-        uses: actions/upload-artifact@v4
-        timeout-minutes: 5
-        continue-on-error: true
-        with:
-          name: ${{ steps.upload_params_packed.outputs.artifact_name }}
-          path: ${{ steps.target_parent_path.outputs.PARENT_PATH }}/target/${{ inputs.buildStage }}/release/packed/${{ inputs.packageName }}.exe
-          overwrite: true
-
-      - name: Upload packed artifact 第 1 次失败通知
-        if: inputs.usePack == 'true' && inputs.buildStage == 'product' && steps.upload_packed_1.outcome == 'failure'
-        uses: foxundermoon/feishu-action@v2
-        with:
-          url: ${{ secrets.webhookFeishu }}
-          msg_type: post
-          content: |
-            post:
-              zh_cn:
-                title: ⚠️ ${{ inputs.projectName }} Upload packed artifact 失败 (1/3)，自动重试中...
-                content:
-                - - tag: text
-                    un_escape: true
-                    text: '部署环境: ${{ inputs.buildStage }}'
-                - - tag: text
-                    text: '部署链接: '
-                  - tag: a
-                    text: github action
-                    href: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
-      - name: Upload packed artifact (尝试 2/3)
-        if: inputs.usePack == 'true' && inputs.buildStage == 'product' && steps.upload_packed_1.outcome == 'failure'
-        id: upload_packed_2
-        uses: actions/upload-artifact@v4
-        timeout-minutes: 5
-        continue-on-error: true
-        with:
-          name: ${{ steps.upload_params_packed.outputs.artifact_name }}
-          path: ${{ steps.target_parent_path.outputs.PARENT_PATH }}/target/${{ inputs.buildStage }}/release/packed/${{ inputs.packageName }}.exe
-          overwrite: true
-
-      - name: Upload packed artifact 第 2 次失败通知
-        if: inputs.usePack == 'true' && inputs.buildStage == 'product' && steps.upload_packed_2.outcome == 'failure'
-        uses: foxundermoon/feishu-action@v2
-        with:
-          url: ${{ secrets.webhookFeishu }}
-          msg_type: post
-          content: |
-            post:
-              zh_cn:
-                title: ⚠️ ${{ inputs.projectName }} Upload packed artifact 失败 (2/3)，自动重试中...
-                content:
-                - - tag: text
-                    un_escape: true
-                    text: '部署环境: ${{ inputs.buildStage }}'
-                - - tag: text
-                    text: '部署链接: '
-                  - tag: a
-                    text: github action
-                    href: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
-      - name: Upload packed artifact (尝试 3/3)
-        if: inputs.usePack == 'true' && inputs.buildStage == 'product' && steps.upload_packed_2.outcome == 'failure'
-        id: upload_packed_3
-        uses: actions/upload-artifact@v4
-        timeout-minutes: 5
-        continue-on-error: true
-        with:
-          name: ${{ steps.upload_params_packed.outputs.artifact_name }}
-          path: ${{ steps.target_parent_path.outputs.PARENT_PATH }}/target/${{ inputs.buildStage }}/release/packed/${{ inputs.packageName }}.exe
-          overwrite: true
-
-      - name: Upload packed artifact 最终检查
-        if: inputs.usePack == 'true' && inputs.buildStage == 'product' && steps.upload_packed_1.outcome == 'failure' && steps.upload_packed_2.outcome == 'failure' && steps.upload_packed_3.outcome == 'failure'
-        shell: powershell
-        run: |
-          Write-Host "Upload packed artifact failed 3 times in a row"
-          exit 1
+          $secretId = '${{ secrets.TENCENT_SECRET_ID }}'
+          $secretKey = '${{ secrets.TENCENT_SECRET_KEY }}'
+          $region = '${{ inputs.tencentRegion }}'
+          $bucket = '${{ inputs.bucket }}'
+          $key = 'windows/release/packed/${{ inputs.packageName }}-${{ github.ref_name }}.exe'
+          $local = "${{ steps.target_parent_path.outputs.PARENT_PATH }}\target\${{ inputs.buildStage }}\release\packed\${{ inputs.packageName }}.exe"
+          .\coscli.exe --secret-id $secretId --secret-key $secretKey --region $region --bucket $bucket --key $key --local $local --retries ${{ inputs.retries }}
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }    
 
       - name: 构建成功通知
         if: success()
@@ -378,77 +256,6 @@ jobs:
                     text: github action
                     href: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-      - name: Download artifact product
-        if: inputs.buildStage == 'product'
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ inputs.packageName }}-${{ inputs.buildStage }}-${{ github.ref_name }}-${{ github.sha }}.exe
-          path: ./
-
-      - name: Download packed artifact product
-        if: inputs.buildStage == 'product' && inputs.usePack == 'true'
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ inputs.packageName }}-${{ inputs.buildStage }}-${{ github.ref_name }}-${{ github.sha }}-packed.exe
-          path: ./packed/
-
-      - name: Download artifact
-        if: inputs.buildStage != 'product'
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ inputs.packageName }}-${{ inputs.buildStage }}-${{ github.sha }}.exe
-          path: ./
-
-      - name: Display structure of downloaded files
-        run: ls -R
-
-      - name: Upload main to S3 (packed, product)
-        if: inputs.buildStage == 'product' && inputs.usePack == 'true'
-        uses: keithweaver/aws-s3-github-action@v1.0.0
-        with:
-          command: cp
-          source: ./packed/${{ inputs.packageName }}.exe
-          destination: s3://${{ inputs.bucket }}/windows/release/${{ inputs.packageName }}-${{ github.ref_name }}.exe
-          aws_access_key_id: ${{ secrets.awsAccessKey }}
-          aws_secret_access_key: ${{ secrets.awsSecretKey }}
-          aws_region: ${{ inputs.awsRegion }}
-          flags: --acl public-read
-
-      - name: Upload main to S3 (unpacked, product)
-        if: inputs.buildStage == 'product' && inputs.usePack != 'true'
-        uses: keithweaver/aws-s3-github-action@v1.0.0
-        with:
-          command: cp
-          source: ./${{ inputs.packageName }}.exe
-          destination: s3://${{ inputs.bucket }}/windows/release/${{ inputs.packageName }}-${{  github.ref_name }}.exe
-          aws_access_key_id: ${{ secrets.awsAccessKey }}
-          aws_secret_access_key: ${{ secrets.awsSecretKey }}
-          aws_region: ${{ inputs.awsRegion }}
-          flags: --acl public-read
-
-      - name: Upload backup (unpacked) to S3 (product)
-        if: inputs.buildStage == 'product' && inputs.usePack == 'true'
-        uses: keithweaver/aws-s3-github-action@v1.0.0
-        with:
-          command: cp
-          source: ./${{ inputs.packageName }}.exe
-          destination: s3://${{ inputs.bucket }}/windows/release/unpacked/${{ inputs.packageName }}-${{ github.ref_name }}.exe
-          aws_access_key_id: ${{ secrets.awsAccessKey }}
-          aws_secret_access_key: ${{ secrets.awsSecretKey }}
-          aws_region: ${{ inputs.awsRegion }}
-          flags: --acl public-read
-
-      - name: Upload to S3
-        if: inputs.buildStage != 'product'
-        uses: keithweaver/aws-s3-github-action@v1.0.0
-        with:
-          command: cp
-          source: ./${{ inputs.packageName }}.exe
-          destination: s3://${{ inputs.bucket }}/windows/${{ inputs.buildStage }}/${{ inputs.packageName }}-${{ github.ref_name }}-${{ github.sha }}.exe
-          aws_access_key_id: ${{ secrets.awsAccessKey }}
-          aws_secret_access_key: ${{ secrets.awsSecretKey }}
-          aws_region: ${{ inputs.awsRegion }}
-          flags: --acl public-read
 
       - name: update version
         if: inputs.buildStage != 'dev'
@@ -466,7 +273,7 @@ jobs:
           url: ${{ secrets.updateApi }}/windows/update
           method: "POST"
           customHeaders: '{"Content-Type": "application/json"}'
-          data: '{"link": "https://${{ inputs.bucket }}.s3.amazonaws.com/windows/release/${{ inputs.packageName }}-${{  github.ref_name }}.exe"}'
+          data: '{"link": "https://${{ inputs.bucket }}.cos.ap-seoul.myqcloud.com/windows/release/${{ inputs.packageName }}-${{  github.ref_name }}.exe"}'
 
       - name: 发布成功通知
         if: success() && inputs.buildStage != 'product'
@@ -490,7 +297,7 @@ jobs:
                 - - tag: text
                     text: '下载链接: '
                   - tag: text
-                    text: https://${{ inputs.bucket }}.s3.amazonaws.com/windows/${{ inputs.buildStage }}/${{ inputs.packageName }}-${{ github.ref_name }}-${{ github.sha }}.exe
+                    text: https://${{ inputs.bucket }}.cos.ap-seoul.myqcloud.com/${{ inputs.buildStage }}/${{ inputs.packageName }}-${{ github.ref_name }}-${{ github.sha }}.exe
 
       - name: 发布成功通知 (product)
         if: success() && inputs.buildStage == 'product'
@@ -514,7 +321,7 @@ jobs:
                 - - tag: text
                     text: '下载链接: '
                   - tag: text
-                    text: https://${{ inputs.bucket }}.s3.amazonaws.com/windows/release/${{ inputs.packageName }}-${{  github.ref_name }}.exe
+                    text: https://${{ inputs.bucket }}.cos.ap-seoul.myqcloud.com/windows/release/${{ inputs.packageName }}-${{  github.ref_name }}.exe
 
       - name: 发布失败通知
         if: failure()

--- a/.github/workflows/rust-exe-update-template.yml
+++ b/.github/workflows/rust-exe-update-template.yml
@@ -13,7 +13,7 @@ on:
         required: true
         type: string
         default: ""
-      tencentRegion:
+      awsRegion:
         required: true
         type: string
       bucket:
@@ -23,16 +23,12 @@ on:
         required: false
         type: string
         default: 'false'
-      retries:
-        required: false
-        type: number
-        default: 3
     secrets:
       webhookFeishu:
         required: true
-      TENCENT_SECRET_ID:
+      awsAccessKey:
         required: false
-      TENCENT_SECRET_KEY:
+      awsSecretKey:
         required: false
       updateApi:
         required: true
@@ -115,57 +111,183 @@ jobs:
           $parentPath = Split-Path -Parent (Get-Location).Path
           echo "PARENT_PATH=$parentPath" >> $env:GITHUB_OUTPUT
 
-      - name: Upload unpacked via coscli
-        if: inputs.usePack != 'true' && inputs.buildStage != 'product'
+      - name: 设置上传参数
+        id: upload_params
         shell: powershell
         run: |
-          $secretId = '${{ secrets.TENCENT_SECRET_ID }}'
-          $secretKey = '${{ secrets.TENCENT_SECRET_KEY }}'
-          $region = '${{ inputs.tencentRegion }}'
-          $bucket = '${{ inputs.bucket }}'
-          $key = 'windows/${{ inputs.buildStage }}/unpacked/${{ inputs.packageName }}-${{ github.ref_name }}-${{ github.sha }}.exe'
-          $local = "${{ steps.target_parent_path.outputs.PARENT_PATH }}\target\${{ inputs.buildStage }}\release\${{ inputs.packageName }}.exe"
-          .\coscli.exe --secret-id $secretId --secret-key $secretKey --region $region --bucket $bucket --key $key --local $local --retries ${{ inputs.retries }}
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }    
+          if ('${{ inputs.buildStage }}' -eq 'product') {
+            $name = '${{ inputs.packageName }}-${{ inputs.buildStage }}-${{ github.ref_name }}-${{ github.sha }}.exe'
+          } else {
+            $name = '${{ inputs.packageName }}-${{ inputs.buildStage }}-${{ github.sha }}.exe'
+          }
+          echo "artifact_name=$name" >> $env:GITHUB_OUTPUT
 
-      - name: Upload product unpacked via coscli
-        if: inputs.usePack == 'true' && inputs.buildStage != 'product'
+      - name: Upload artifact (尝试 1/3)
+        id: upload_1
+        uses: actions/upload-artifact@v4
+        timeout-minutes: 5
+        continue-on-error: true
+        with:
+          name: ${{ steps.upload_params.outputs.artifact_name }}
+          path: ${{ steps.target_parent_path.outputs.PARENT_PATH }}/target/${{ inputs.buildStage }}/release/${{ inputs.packageName }}.exe
+          overwrite: true
+
+      - name: Upload artifact 第 1 次失败通知
+        if: steps.upload_1.outcome == 'failure'
+        uses: foxundermoon/feishu-action@v2
+        with:
+          url: ${{ secrets.webhookFeishu }}
+          msg_type: post
+          content: |
+            post:
+              zh_cn:
+                title: ⚠️ ${{ inputs.projectName }} Upload artifact 失败 (1/3)，自动重试中...
+                content:
+                - - tag: text
+                    un_escape: true
+                    text: '部署环境: ${{ inputs.buildStage }}'
+                - - tag: text
+                    text: '部署链接: '
+                  - tag: a
+                    text: github action
+                    href: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+      - name: Upload artifact (尝试 2/3)
+        if: steps.upload_1.outcome == 'failure'
+        id: upload_2
+        uses: actions/upload-artifact@v4
+        timeout-minutes: 5
+        continue-on-error: true
+        with:
+          name: ${{ steps.upload_params.outputs.artifact_name }}
+          path: ${{ steps.target_parent_path.outputs.PARENT_PATH }}/target/${{ inputs.buildStage }}/release/${{ inputs.packageName }}.exe
+          overwrite: true
+
+      - name: Upload artifact 第 2 次失败通知
+        if: steps.upload_2.outcome == 'failure'
+        uses: foxundermoon/feishu-action@v2
+        with:
+          url: ${{ secrets.webhookFeishu }}
+          msg_type: post
+          content: |
+            post:
+              zh_cn:
+                title: ⚠️ ${{ inputs.projectName }} Upload artifact 失败 (2/3)，自动重试中...
+                content:
+                - - tag: text
+                    un_escape: true
+                    text: '部署环境: ${{ inputs.buildStage }}'
+                - - tag: text
+                    text: '部署链接: '
+                  - tag: a
+                    text: github action
+                    href: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+      - name: Upload artifact (尝试 3/3)
+        if: steps.upload_2.outcome == 'failure'
+        id: upload_3
+        uses: actions/upload-artifact@v4
+        timeout-minutes: 5
+        continue-on-error: true
+        with:
+          name: ${{ steps.upload_params.outputs.artifact_name }}
+          path: ${{ steps.target_parent_path.outputs.PARENT_PATH }}/target/${{ inputs.buildStage }}/release/${{ inputs.packageName }}.exe
+          overwrite: true
+
+      - name: Upload artifact 最终检查
+        if: steps.upload_1.outcome == 'failure' && steps.upload_2.outcome == 'failure' && steps.upload_3.outcome == 'failure'
         shell: powershell
         run: |
-          $secretId = '${{ secrets.TENCENT_SECRET_ID }}'
-          $secretKey = '${{ secrets.TENCENT_SECRET_KEY }}'
-          $region = '${{ inputs.tencentRegion }}'
-          $bucket = '${{ inputs.bucket }}'
-          $key = '$/windows/${{ inputs.buildStage }}/${{ inputs.packageName }}-${{ github.ref_name }}-${{ github.sha }}.exe'
-          $local = "${{ steps.target_parent_path.outputs.PARENT_PATH }}\target\${{ inputs.buildStage }}\release\packed\${{ inputs.packageName }}.exe"
-          .\coscli.exe --secret-id $secretId --secret-key $secretKey --region $region --bucket $bucket --key $key --local $local --retries ${{ inputs.retries }}
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          Write-Host "Upload artifact failed 3 times in a row"
+          exit 1
 
-      - name: Upload Product unpacked via coscli
-        if: inputs.buildStage == 'product'
-        shell: powershell
-        run: |
-          $secretId = '${{ secrets.TENCENT_SECRET_ID }}'
-          $secretKey = '${{ secrets.TENCENT_SECRET_KEY }}'
-          $region = '${{ inputs.tencentRegion }}'
-          $bucket = '${{ inputs.bucket }}'
-          $key = 'windows/release/unpacked-${{ github.sha }}/${{ inputs.packageName }}-${{ github.ref_name }}.exe'
-          $local = "${{ steps.target_parent_path.outputs.PARENT_PATH }}\target\${{ inputs.buildStage }}\release\${{ inputs.packageName }}.exe"
-          .\coscli.exe --secret-id $secretId --secret-key $secretKey --region $region --bucket $bucket --key $key --local $local --retries ${{ inputs.retries }}
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-      - name: Upload product packed via coscli
+      - name: 设置 packed 上传参数
+        id: upload_params_packed
         if: inputs.usePack == 'true' && inputs.buildStage == 'product'
         shell: powershell
         run: |
-          $secretId = '${{ secrets.TENCENT_SECRET_ID }}'
-          $secretKey = '${{ secrets.TENCENT_SECRET_KEY }}'
-          $region = '${{ inputs.tencentRegion }}'
-          $bucket = '${{ inputs.bucket }}'
-          $key = 'windows/release/${{ inputs.packageName }}-${{ github.ref_name }}.exe'
-          $local = "${{ steps.target_parent_path.outputs.PARENT_PATH }}\target\${{ inputs.buildStage }}\release\packed\${{ inputs.packageName }}.exe"
-          .\coscli.exe --secret-id $secretId --secret-key $secretKey --region $region --bucket $bucket --key $key --local $local --retries ${{ inputs.retries }}
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }    
+          $name = '${{ inputs.packageName }}-${{ inputs.buildStage }}-${{ github.ref_name }}-${{ github.sha }}-packed.exe'
+          echo "artifact_name=$name" >> $env:GITHUB_OUTPUT
+
+      - name: Upload packed artifact (尝试 1/3)
+        if: inputs.usePack == 'true' && inputs.buildStage == 'product'
+        id: upload_packed_1
+        uses: actions/upload-artifact@v4
+        timeout-minutes: 5
+        continue-on-error: true
+        with:
+          name: ${{ steps.upload_params_packed.outputs.artifact_name }}
+          path: ${{ steps.target_parent_path.outputs.PARENT_PATH }}/target/${{ inputs.buildStage }}/release/packed/${{ inputs.packageName }}.exe
+          overwrite: true
+
+      - name: Upload packed artifact 第 1 次失败通知
+        if: inputs.usePack == 'true' && inputs.buildStage == 'product' && steps.upload_packed_1.outcome == 'failure'
+        uses: foxundermoon/feishu-action@v2
+        with:
+          url: ${{ secrets.webhookFeishu }}
+          msg_type: post
+          content: |
+            post:
+              zh_cn:
+                title: ⚠️ ${{ inputs.projectName }} Upload packed artifact 失败 (1/3)，自动重试中...
+                content:
+                - - tag: text
+                    un_escape: true
+                    text: '部署环境: ${{ inputs.buildStage }}'
+                - - tag: text
+                    text: '部署链接: '
+                  - tag: a
+                    text: github action
+                    href: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+      - name: Upload packed artifact (尝试 2/3)
+        if: inputs.usePack == 'true' && inputs.buildStage == 'product' && steps.upload_packed_1.outcome == 'failure'
+        id: upload_packed_2
+        uses: actions/upload-artifact@v4
+        timeout-minutes: 5
+        continue-on-error: true
+        with:
+          name: ${{ steps.upload_params_packed.outputs.artifact_name }}
+          path: ${{ steps.target_parent_path.outputs.PARENT_PATH }}/target/${{ inputs.buildStage }}/release/packed/${{ inputs.packageName }}.exe
+          overwrite: true
+
+      - name: Upload packed artifact 第 2 次失败通知
+        if: inputs.usePack == 'true' && inputs.buildStage == 'product' && steps.upload_packed_2.outcome == 'failure'
+        uses: foxundermoon/feishu-action@v2
+        with:
+          url: ${{ secrets.webhookFeishu }}
+          msg_type: post
+          content: |
+            post:
+              zh_cn:
+                title: ⚠️ ${{ inputs.projectName }} Upload packed artifact 失败 (2/3)，自动重试中...
+                content:
+                - - tag: text
+                    un_escape: true
+                    text: '部署环境: ${{ inputs.buildStage }}'
+                - - tag: text
+                    text: '部署链接: '
+                  - tag: a
+                    text: github action
+                    href: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+      - name: Upload packed artifact (尝试 3/3)
+        if: inputs.usePack == 'true' && inputs.buildStage == 'product' && steps.upload_packed_2.outcome == 'failure'
+        id: upload_packed_3
+        uses: actions/upload-artifact@v4
+        timeout-minutes: 5
+        continue-on-error: true
+        with:
+          name: ${{ steps.upload_params_packed.outputs.artifact_name }}
+          path: ${{ steps.target_parent_path.outputs.PARENT_PATH }}/target/${{ inputs.buildStage }}/release/packed/${{ inputs.packageName }}.exe
+          overwrite: true
+
+      - name: Upload packed artifact 最终检查
+        if: inputs.usePack == 'true' && inputs.buildStage == 'product' && steps.upload_packed_1.outcome == 'failure' && steps.upload_packed_2.outcome == 'failure' && steps.upload_packed_3.outcome == 'failure'
+        shell: powershell
+        run: |
+          Write-Host "Upload packed artifact failed 3 times in a row"
+          exit 1
 
       - name: 构建成功通知
         if: success()
@@ -225,7 +347,18 @@ jobs:
         uses: ASzc/change-string-case-action@v5
         with:
           string: ${{ runner.os }}
+    outputs:
+      os: ${{ steps.output.outputs.lowercase }}
+      version: ${{ steps.version.outputs.version }}
 
+  upload:
+    strategy:
+      matrix:
+        platform: [ubuntu-latest]
+    runs-on: ${{ matrix.platform }}
+    needs: build_rust
+
+    steps:
       - name: post messasge
         uses: foxundermoon/feishu-action@v2
         with:
@@ -245,6 +378,77 @@ jobs:
                     text: github action
                     href: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
+      - name: Download artifact product
+        if: inputs.buildStage == 'product'
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.packageName }}-${{ inputs.buildStage }}-${{ github.ref_name }}-${{ github.sha }}.exe
+          path: ./
+
+      - name: Download packed artifact product
+        if: inputs.buildStage == 'product' && inputs.usePack == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.packageName }}-${{ inputs.buildStage }}-${{ github.ref_name }}-${{ github.sha }}-packed.exe
+          path: ./packed/
+
+      - name: Download artifact
+        if: inputs.buildStage != 'product'
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.packageName }}-${{ inputs.buildStage }}-${{ github.sha }}.exe
+          path: ./
+
+      - name: Display structure of downloaded files
+        run: ls -R
+
+      - name: Upload main to S3 (packed, product)
+        if: inputs.buildStage == 'product' && inputs.usePack == 'true'
+        uses: keithweaver/aws-s3-github-action@v1.0.0
+        with:
+          command: cp
+          source: ./packed/${{ inputs.packageName }}.exe
+          destination: s3://${{ inputs.bucket }}/windows/release/${{ inputs.packageName }}-${{ github.ref_name }}.exe
+          aws_access_key_id: ${{ secrets.awsAccessKey }}
+          aws_secret_access_key: ${{ secrets.awsSecretKey }}
+          aws_region: ${{ inputs.awsRegion }}
+          flags: --acl public-read
+
+      - name: Upload main to S3 (unpacked, product)
+        if: inputs.buildStage == 'product' && inputs.usePack != 'true'
+        uses: keithweaver/aws-s3-github-action@v1.0.0
+        with:
+          command: cp
+          source: ./${{ inputs.packageName }}.exe
+          destination: s3://${{ inputs.bucket }}/windows/release/${{ inputs.packageName }}-${{  github.ref_name }}.exe
+          aws_access_key_id: ${{ secrets.awsAccessKey }}
+          aws_secret_access_key: ${{ secrets.awsSecretKey }}
+          aws_region: ${{ inputs.awsRegion }}
+          flags: --acl public-read
+
+      - name: Upload backup (unpacked) to S3 (product)
+        if: inputs.buildStage == 'product' && inputs.usePack == 'true'
+        uses: keithweaver/aws-s3-github-action@v1.0.0
+        with:
+          command: cp
+          source: ./${{ inputs.packageName }}.exe
+          destination: s3://${{ inputs.bucket }}/windows/release/unpacked/${{ inputs.packageName }}-${{ github.ref_name }}.exe
+          aws_access_key_id: ${{ secrets.awsAccessKey }}
+          aws_secret_access_key: ${{ secrets.awsSecretKey }}
+          aws_region: ${{ inputs.awsRegion }}
+          flags: --acl public-read
+
+      - name: Upload to S3
+        if: inputs.buildStage != 'product'
+        uses: keithweaver/aws-s3-github-action@v1.0.0
+        with:
+          command: cp
+          source: ./${{ inputs.packageName }}.exe
+          destination: s3://${{ inputs.bucket }}/windows/${{ inputs.buildStage }}/${{ inputs.packageName }}-${{ github.ref_name }}-${{ github.sha }}.exe
+          aws_access_key_id: ${{ secrets.awsAccessKey }}
+          aws_secret_access_key: ${{ secrets.awsSecretKey }}
+          aws_region: ${{ inputs.awsRegion }}
+          flags: --acl public-read
 
       - name: update version
         if: inputs.buildStage != 'dev'
@@ -262,7 +466,7 @@ jobs:
           url: ${{ secrets.updateApi }}/windows/update
           method: "POST"
           customHeaders: '{"Content-Type": "application/json"}'
-          data: '{"link": "https://${{ inputs.bucket }}.cos.ap-seoul.myqcloud.com/windows/release/${{ inputs.packageName }}-${{  github.ref_name }}.exe"}'
+          data: '{"link": "https://${{ inputs.bucket }}.s3.amazonaws.com/windows/release/${{ inputs.packageName }}-${{  github.ref_name }}.exe"}'
 
       - name: 发布成功通知
         if: success() && inputs.buildStage != 'product'
@@ -286,7 +490,7 @@ jobs:
                 - - tag: text
                     text: '下载链接: '
                   - tag: text
-                    text: https://${{ inputs.bucket }}.cos.ap-seoul.myqcloud.com/windows/${{ inputs.buildStage }}/${{ inputs.packageName }}-${{ github.ref_name }}-${{ github.sha }}.exe
+                    text: https://${{ inputs.bucket }}.s3.amazonaws.com/windows/${{ inputs.buildStage }}/${{ inputs.packageName }}-${{ github.ref_name }}-${{ github.sha }}.exe
 
       - name: 发布成功通知 (product)
         if: success() && inputs.buildStage == 'product'
@@ -310,7 +514,7 @@ jobs:
                 - - tag: text
                     text: '下载链接: '
                   - tag: text
-                    text: https://${{ inputs.bucket }}.cos.ap-seoul.myqcloud.com/windows/release/${{ inputs.packageName }}-${{  github.ref_name }}.exe
+                    text: https://${{ inputs.bucket }}.s3.amazonaws.com/windows/release/${{ inputs.packageName }}-${{  github.ref_name }}.exe
 
       - name: 发布失败通知
         if: failure()
@@ -345,6 +549,3 @@ jobs:
                 }
               ]
             }
-    outputs:
-      os: ${{ steps.output.outputs.lowercase }}
-      version: ${{ steps.version.outputs.version }}


### PR DESCRIPTION
- 将awsRegion参数替换为tencentRegion参数
- 将awsAccessKey和awsSecretKey密钥替换为TENCENT_SECRET_ID和TENCENT_SECRET_KEY
- 添加retries参数用于配置上传重试次数，默认值为3
- 注释掉Rust版本更新步骤
- 使用coscli工具替代AWS S3上传功能
- 移除原有的GitHub artifacts上传逻辑
- 更新API端点URL从s3.amazonaws.com切换到cos.ap-seoul.myqcloud.com
- 重构工作流文件结构，将上传逻辑整合到统一的upload任务中
- 保留飞书通知功能并适配新的上传流程