### PR TITLE
fix(workflow): 修复GitHub工作流中的条件判断和步骤依赖问题

### DIFF
--- a/.github/workflows/rust-exe-update-template.yml
+++ b/.github/workflows/rust-exe-update-template.yml
@@ -126,7 +126,7 @@ jobs:
           $key = 'windows/${{ inputs.buildStage }}/${{ inputs.packageName }}-${{ github.ref_name }}-${{ github.sha }}.exe'
           $local = "${{ steps.target_parent_path.outputs.PARENT_PATH }}\target\${{ inputs.buildStage }}\release\${{ inputs.packageName }}.exe"
           .\coscli.exe --secret-id $secretId --secret-key $secretKey --region $region --bucket $bucket --key $key --local $local --retries ${{ inputs.retries }}
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }    
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Upload Product unpacked via coscli
         if: inputs.buildStage == 'product'
@@ -152,10 +152,24 @@ jobs:
           $key = 'windows/release/${{ inputs.packageName }}-${{ github.ref_name }}.exe'
           $local = "${{ steps.target_parent_path.outputs.PARENT_PATH }}\target\${{ inputs.buildStage }}\release\packed\${{ inputs.packageName }}.exe"
           .\coscli.exe --secret-id $secretId --secret-key $secretKey --region $region --bucket $bucket --key $key --local $local --retries ${{ inputs.retries }}
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }    
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
+      - id: output
+        uses: ASzc/change-string-case-action@v5
+        with:
+          string: ${{ runner.os }}
+
+    outputs:
+      os: ${{ steps.output.outputs.lowercase }}
+      version: ${{ steps.version.outputs.version }}
+
+  notify_release:
+    needs: build_rust
+    if: always()
+    runs-on: ubuntu-22.04
+    steps:
       - name: 构建成功通知
-        if: success()
+        if: needs.build_rust.result == 'success'
         uses: foxundermoon/feishu-action@v2
         with:
           url: ${{ secrets.webhookFeishu }}
@@ -175,7 +189,7 @@ jobs:
                     href: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       - name: 构建失败通知
-        if: failure()
+        if: needs.build_rust.result == 'failure'
         uses: foxundermoon/feishu-action@v2
         with:
           url: ${{ secrets.webhookFeishu }}
@@ -208,12 +222,8 @@ jobs:
               ]
             }
 
-      - id: output
-        uses: ASzc/change-string-case-action@v5
-        with:
-          string: ${{ runner.os }}
-
       - name: post messasge
+        if: needs.build_rust.result == 'success'
         uses: foxundermoon/feishu-action@v2
         with:
           url: ${{ secrets.webhookFeishu }}
@@ -232,18 +242,17 @@ jobs:
                     text: github action
                     href: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-
       - name: update version
-        if: inputs.buildStage != 'dev'
+        if: needs.build_rust.result == 'success' && inputs.buildStage != 'dev'
         uses: fjogeleit/http-request-action@v1
         with:
           url: ${{ secrets.updateApi }}/version/update
           method: "POST"
           customHeaders: '{"Content-Type": "application/json"}'
-          data: '{"platform": "windows", "env": "${{ inputs.buildStage }}", "version": "${{ steps.version.outputs.version }}", "hash": "${{ github.sha }}"}'
+          data: '{"platform": "windows", "env": "${{ inputs.buildStage }}", "version": "${{ needs.build_rust.outputs.version }}", "hash": "${{ github.sha }}"}'
 
       - name: update download
-        if: inputs.buildStage == 'product'
+        if: needs.build_rust.result == 'success' && inputs.buildStage == 'product'
         uses: fjogeleit/http-request-action@v1
         with:
           url: ${{ secrets.updateApi }}/windows/update
@@ -251,15 +260,6 @@ jobs:
           customHeaders: '{"Content-Type": "application/json"}'
           data: '{"link": "https://${{ inputs.bucket }}.cos.ap-seoul.myqcloud.com/windows/release/${{ inputs.packageName }}-${{  github.ref_name }}.exe"}'
 
-    outputs:
-      os: ${{ steps.output.outputs.lowercase }}
-      version: ${{ steps.version.outputs.version }}
-
-  notify_release:
-    needs: build_rust
-    if: always()
-    runs-on: ubuntu-22.04
-    steps:
       - name: 发布成功通知
         if: needs.build_rust.result == 'success' && inputs.buildStage != 'product'
         uses: foxundermoon/feishu-action@v2
@@ -333,7 +333,7 @@ jobs:
                     text: https://${{ inputs.bucket }}.cos.ap-seoul.myqcloud.com/windows/release/unpacked-${{ github.sha }}/${{ inputs.packageName }}-${{ github.ref_name }}.exe
 
       - name: 发布失败通知
-        if: needs.build_rust.result == 'failure'
+        if: failure() || needs.build_rust.result == 'failure'
         uses: foxundermoon/feishu-action@v2
         with:
           url: ${{ secrets.webhookFeishu }}


### PR DESCRIPTION
- 修复了Windows可执行文件上传步骤中的重复代码
- 添加了OS检测步骤并优化了输出变量配置
- 重构了构建通知逻辑，使用needs依赖替代success/failure条件
- 修复了版本更新步骤中的变量引用错误
- 统一了发布通知的触发条件判断逻辑
- 优化了工作流步骤间的依赖关系配置