### PR TITLE
💥 feat(tauri-ci): 加 enablePack input 控制套壳

### DIFF
--- a/.github/workflows/tauri-build-template.yml
+++ b/.github/workflows/tauri-build-template.yml
@@ -36,6 +36,11 @@ on:
             awsPath:
                 required: true
                 type: string
+            enablePack:
+                required: false
+                type: boolean
+                default: false
+                description: "是否在 Tauri bundling 前调用调用方仓库内的 scripts/pre-bundle.js 给主 exe 套壳（仅当调用方搭了该钩子时生效）"
         secrets:
             awsAccessKey:
                 required: true
@@ -203,6 +208,9 @@ jobs:
                   TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ vars.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
                   RUSTFLAGS: '--cfg env="${{ inputs.releaseType }}"'
                   CARGO_TARGET_DIR: "${{ steps.target-cache-dir.outputs.result }}/gui/${{ inputs.releaseType }}"
+                  # 调用方 enablePack=true 时给 pre-bundle.js 钩子打开套壳开关；
+                  # 否则保持空，钩子检测到 PACK_ENABLED!="1" 走 no-op 分支。
+                  PACK_ENABLED: ${{ inputs.enablePack && '1' || '' }}
               with:
                   args: |
                       -f ${{ inputs.buildStage }}


### PR DESCRIPTION
## 摘要

给 \`tauri-build-template.yml\` 加一个可选 input \`enablePack\`（默认 \`false\`），在 \`tauri-action\` step 的 env 里注入 \`PACK_ENABLED=\"1\"\`（启用时）或 \`PACK_ENABLED=\"\"\`（禁用时）。

调用方仓库要先在自家 \`tauri.conf.json\` 配好 \`beforeBundleCommand\` 钩子（指向 \`scripts/pre-bundle.js\` 之类），\`enablePack: true\` 时钩子检测到环境变量执行套壳；否则钩子走 no-op 分支。

## 兼容性

对**未传 \`enablePack\`** 的现有调用方**完全无副作用**：
- \`default: false\` → \`PACK_ENABLED=\"\"\`
- 没配 \`beforeBundleCommand\` 钩子的项目：环境变量没人读，零影响
- 配了钩子的项目：钩子检测到 \`PACK_ENABLED!=\"1\"\` 走 no-op，零影响

## 首个使用方

[ReverseGame/reverse-bot-gui#1213](https://github.com/ReverseGame/reverse-bot-gui/pull/1213) 已搭好 \`scripts/pre-bundle.js\` 钩子（调用 [AntiDecompiler](https://github.com/ReverseGame/AntiDecompiler) 加壳工具）。该 PR 合入后会在 \`xbot-gui-ci-internal.yaml\` 引用此模板时传 \`enablePack: true\` 启用套壳。Product CI 暂不启用，待内部版本灰度一阵稳定后再同步。

## Test Plan

- [x] 现有调用方（未传 enablePack）行为不变 — 默认 \`enablePack: false\` → env 注入空串 → 等价于改前
- [ ] reverse-bot-gui internal CI 加 \`enablePack: true\` 后手动 workflow_dispatch 验证：tauri-action 实际拿到 \`PACK_ENABLED=1\` env，pre-bundle.js 走套壳分支，msi 内嵌的 exe 是套壳产物