### PR TITLE
feat(workflow): tauri dispatch 支持 GitHub App token

### DIFF
--- a/.github/workflows/tauri-build-template-dispatch.yml
+++ b/.github/workflows/tauri-build-template-dispatch.yml
@@ -26,6 +26,11 @@ on:
       bucket:
         required: true
         type: string
+      useAppToken:
+        required: false
+        type: boolean
+        default: false
+        description: "true=使用 GitHub App token (需传 appId/appPrivateKey)；false=沿用 patToken"
     secrets:
       awsAccessKey:
         required: true
@@ -36,7 +41,14 @@ on:
       tauriKeyPassword:
         required: true
       patToken:
-        required: true
+        required: false
+        description: "PAT token，useAppToken=false 时必填（默认方案）"
+      appId:
+        required: false
+        description: "GitHub App ID，useAppToken=true 时必填"
+      appPrivateKey:
+        required: false
+        description: "GitHub App private key (PEM)，useAppToken=true 时必填"
 
 jobs:
   pr_new_version:
@@ -45,6 +57,14 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: Generate GitHub App Token (可选)
+        if: ${{ inputs.useAppToken }}
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.appId }}
+          private-key: ${{ secrets.appPrivateKey }}
+
       - name: Echo client_payload
         run: |
           echo "client_payload sha: ${{ github.event.client_payload.sha }}"
@@ -53,7 +73,7 @@ jobs:
       - name: Checkout code (检出代码)
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.patToken }}
+          token: ${{ steps.app-token.outputs.token || secrets.patToken }}
           submodules: recursive
           fetch-depth: 0
       - name: show dir list
@@ -90,6 +110,7 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         id: cpr
         with:
+          token: ${{ steps.app-token.outputs.token || secrets.patToken }}
           add-paths: |
             ${{ steps.update_submodule.outputs.repo_name }}
           commit-message: "[create-pull-request] ${{ github.event.client_payload.message }}"
@@ -101,7 +122,7 @@ jobs:
         run: |
           gh pr merge ${{ steps.cpr.outputs.pull-request-number }} --admin --merge
         env:
-          GH_TOKEN: ${{ secrets.patToken }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.patToken }}
 
       - name: post success message
         uses: foxundermoon/feishu-action@v2


### PR DESCRIPTION
## 变更摘要

为 `tauri-build-template-dispatch.yml` 增加 GitHub App token 支持，**完全向后兼容**原 PAT 方案。

## 背景

master 分支启用了 "需要 PR + 1 人 approve" 的 ruleset，自动合并 action 会被规则拦截。  
如果把 PAT 持有者整账号加进 bypass list，则日常开发的 PR 也会失去保护——bypass 是按 actor 粒度的。

**正确做法**：建一个专属 GitHub App，仅把它加进 ruleset 的 bypass list。只在该自动合并 workflow 中使用 App token，其他场景（人类发 PR、其他 workflow 用 `GITHUB_TOKEN`）不受影响。

## 改动

| 类型 | 内容 |
|---|---|
| 新 input | `useAppToken: boolean = false`（开关，默认沿用老逻辑） |
| 新 secret | `appId`、`appPrivateKey` |
| 老 secret | `patToken` 改为 `required: false` |
| 新 step | `Generate GitHub App Token (可选)`，仅 `useAppToken=true` 时执行 |
| 改 step | `checkout` / `create-pull-request` / `gh pr merge` 的 token 改为 `${{ steps.app-token.outputs.token || secrets.patToken }}` |

Fallback 机制：`useAppToken=false` 时 app-token step 跳过，outputs 为空，自动 fallback 到 `patToken`，老调用方零改动。

## 调用方使用方式

**老方式（默认，无需变更）**：
```yaml
with:
  buildStage: prod
  ...
secrets:
  patToken: ${{ secrets.PAT_TOKEN }}
```

**新方式（使用 App token）**：
```yaml
with:
  useAppToken: true
  ...
secrets:
  appId: ${{ vars.MY_APP_ID }}
  appPrivateKey: ${{ secrets.MY_APP_PRIVATE_KEY }}
```

## 前置条件（启用新方式时）

1. 在 org 或 repo 下创建 GitHub App，权限：`Contents: Read & Write`、`Pull requests: Read & Write`
2. 把 App 安装到 PR 创建的目标 repo（如 `reverse-bot-gui`）
3. 把 App 加进目标 repo 的 ruleset **Bypass list**

## 测试计划

- [ ] caller workflow 不传 `useAppToken` → 行为与现网完全一致
- [ ] caller workflow 传 `useAppToken: true` + 正确 App 凭证 → PR 由 App 身份创建并合并，绕过 ruleset
- [ ] caller workflow 传 `useAppToken: true` 但漏传 appId/appPrivateKey → app-token step 报错（预期）