### PR TITLE
feat(workflow): App token 获取失败时自动回退到 patToken

### DIFF
--- a/.github/workflows/tauri-build-template-dispatch.yml
+++ b/.github/workflows/tauri-build-template-dispatch.yml
@@ -60,10 +60,25 @@ jobs:
       - name: Generate GitHub App Token (可选)
         if: ${{ inputs.useAppToken }}
         id: app-token
+        continue-on-error: true
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ secrets.appId }}
           private-key: ${{ secrets.appPrivateKey }}
+
+      - name: Resolve token source (日志)
+        run: |
+          if [ -n "${{ steps.app-token.outputs.token }}" ]; then
+            echo "::notice::使用 GitHub App token (App ID=${{ secrets.appId }})"
+          elif [ "${{ inputs.useAppToken }}" = "true" ]; then
+            echo "::warning::App token 获取失败，自动回退到 patToken"
+          else
+            echo "::notice::使用 patToken (未启用 useAppToken)"
+          fi
+          if [ -z "${{ steps.app-token.outputs.token }}" ] && [ -z "${{ secrets.patToken }}" ]; then
+            echo "::error::App token 和 patToken 都为空，无法继续"
+            exit 1
+          fi
 
       - name: Echo client_payload
         run: |


### PR DESCRIPTION
## 变更摘要

在 #21 的基础上加保底机制：当 GitHub App token 获取失败（凭证错 / App 没装到目标 repo / GitHub API 抖动）时，**自动回退到 patToken**，不再让整个 job 直接失败。

## 改动

1. `Generate GitHub App Token` step 加 `continue-on-error: true` —— 单步失败不阻断 job
2. 新增 `Resolve token source` step，输出诊断信息到 Actions 日志：
   - `notice: 使用 GitHub App token (App ID=...)` —— App token 走通
   - `warning: App token 获取失败，自动回退到 patToken` —— 触发了回退
   - `notice: 使用 patToken (未启用 useAppToken)` —— 默认路径
   - `error: App token 和 patToken 都为空，无法继续` —— fail-fast

后续 step 沿用 `${{ steps.app-token.outputs.token || secrets.patToken }}` 表达式，App token step 失败时 outputs 为空，自动 fallback。

## 四种运行情形

| 输入 | App 获取 | 实际使用 token | 日志 |
|---|---|---|---|
| `useAppToken=false` | 不跑 | patToken | notice |
| `useAppToken=true` + 凭证 OK | ✅ | App token | notice |
| `useAppToken=true` + 凭证错 | ❌ (软失败) | patToken | **warning** |
| 俩都为空 | ❌ | — | **error + 退出** |

## 注意

回退到 patToken 后，由于 PAT 持有者不在 ruleset bypass list 内，合并仍会被规则拦截。这是预期的—— **回退保证 PR 能创建出来 + 日志能看出问题**，让人能及时介入，而不是把整个 CI 跑成黑盒失败。

## 测试计划

- [ ] caller workflow 传 `useAppToken: true` + 错误 `appPrivateKey` → 看到 warning 日志且 PR 能创建
- [ ] caller workflow 传 `useAppToken: true` + 正确凭证 → 看到 notice 日志且合并成功
- [ ] caller workflow `useAppToken: false` → 行为不变