### PR TITLE
perf(ci): rust-exe-update 模板上传改用官方 coscli 并发分片

### DIFF
--- a/.github/workflows/rust-exe-update-template.yml
+++ b/.github/workflows/rust-exe-update-template.yml
@@ -123,9 +123,11 @@ jobs:
           $secretKey = '${{ secrets.TENCENT_SECRET_KEY }}'
           $region = '${{ inputs.tencentRegion }}'
           $bucket = '${{ inputs.bucket }}'
+          $endpoint = "cos.$region.myqcloud.com"
           $key = 'windows/${{ inputs.buildStage }}/${{ inputs.packageName }}-${{ github.ref_name }}-${{ github.sha }}.exe'
           $local = "${{ steps.target_parent_path.outputs.PARENT_PATH }}\target\${{ inputs.buildStage }}\release\${{ inputs.packageName }}.exe"
-          .\coscli.exe --secret-id $secretId --secret-key $secretKey --region $region --bucket $bucket --key $key --local $local --retries ${{ inputs.retries }}
+          # 官方 coscli 并发分片上传(替代原串行上传,大文件大幅提速)
+          .\coscli-official.exe cp $local "cos://$bucket/$key" -e $endpoint -i $secretId -k $secretKey --thread-num 16 --part-size 16 --err-retry-num ${{ inputs.retries }} --init-skip
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 #      - name: Upload Product unpacked via coscli
@@ -149,9 +151,11 @@ jobs:
           $secretKey = '${{ secrets.TENCENT_SECRET_KEY }}'
           $region = '${{ inputs.tencentRegion }}'
           $bucket = '${{ inputs.bucket }}'
+          $endpoint = "cos.$region.myqcloud.com"
           $key = 'windows/release/${{ inputs.packageName }}-${{ github.ref_name }}.exe'
           $local = "${{ steps.target_parent_path.outputs.PARENT_PATH }}\target\${{ inputs.buildStage }}\release\packed\${{ inputs.packageName }}.exe"
-          .\coscli.exe --secret-id $secretId --secret-key $secretKey --region $region --bucket $bucket --key $key --local $local --retries ${{ inputs.retries }}
+          # 官方 coscli 并发分片上传(替代原串行上传,大文件大幅提速)
+          .\coscli-official.exe cp $local "cos://$bucket/$key" -e $endpoint -i $secretId -k $secretKey --thread-num 16 --part-size 16 --err-retry-num ${{ inputs.retries }} --init-skip
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - id: output


### PR DESCRIPTION
## 变更摘要

原模板 `rust-exe-update-template.yml` 使用自定义 `coscli.exe` 串行上传分片,大文件(如 300MB)上传到首尔桶约需 **7 分钟**。

改用**官方 coscli** 的 `cp` 命令并启用**并发分片上传**(`--thread-num 16 --part-size 16`),本地实测 300MB 从 7 分钟降至约 45 秒。

## 改动内容

- `Upload unpacked via coscli` 与 `Upload product packed via coscli` 两处改用 `.\coscli-official.exe cp ... -e <endpoint> --thread-num 16 --part-size 16 --init-skip`
- region 拼成 `cos.<region>.myqcloud.com` 作为 endpoint

## ⚠️ 合并顺序依赖(重要)

`coscli-official.exe` 由**被构建仓库**(reverse-bot-rs)在 checkout 时提供,本模板直接 `.\coscli-official.exe` 调用仓库根的二进制。

**必须先合并 reverse-bot-rs 的对应 PR**([reverse-bot-rs#2924](https://github.com/ReverseGame/reverse-bot-rs/pull/2924),将 `coscli-official.exe` 加入其 master),**再合并本 PR**。否则本模板被调用时会因找不到 `coscli-official.exe` 而失败。

> 注意:本模板被多个仓库以 `@main` 引用,合并后会立即影响所有调用方的非 product 构建上传,请确认它们的默认分支都已包含 `coscli-official.exe`。

## 测试计划

- [ ] reverse-bot-rs#2924 合并后,触发一次 dev/beta 构建(走 build-local),确认官方 coscli 在 self-hosted runner 正常并发上传
- [ ] 确认上传耗时显著下降