### PR TITLE
feat(workflow): App token 支持指定多 repo 访问范围

### DIFF
--- a/.github/workflows/tauri-build-template-dispatch.yml
+++ b/.github/workflows/tauri-build-template-dispatch.yml
@@ -31,6 +31,16 @@ on:
         type: boolean
         default: false
         description: "true=使用 GitHub App token (需传 appId/appPrivateKey)；false=沿用 patToken"
+      tokenRepositories:
+        required: false
+        type: string
+        default: ""
+        description: "App token 需要访问的 repo 列表（逗号或换行分隔，例: reverse-bot-gui,reverse-bot-rs）。省略则仅当前 repo。"
+      tokenOwner:
+        required: false
+        type: string
+        default: ""
+        description: "App token 所属 org/user，省略则用当前 repo 的 owner"
     secrets:
       awsAccessKey:
         required: true
@@ -65,6 +75,8 @@ jobs:
         with:
           app-id: ${{ secrets.appId }}
           private-key: ${{ secrets.appPrivateKey }}
+          owner: ${{ inputs.tokenOwner }}
+          repositories: ${{ inputs.tokenRepositories }}
 
       - name: Resolve token source (日志)
         run: |


### PR DESCRIPTION
## 背景

reverse-bot-gui 一次 dispatch run 的日志显示：

\`\`\`
owner and repositories not set, creating token for the current repository ("reverse-bot-gui")
\`\`\`

\`actions/create-github-app-token@v1\` 默认**只给当前 repo 发 token**。但 tauri dispatch 实际要做 submodule update（fetch / checkout 另一个 repo 如 reverse-bot-rs），单 repo 范围的 App token 会 403。

## 改动

新增 2 个可选 input：

| 名称 | 类型 | 默认 | 说明 |
|---|---|---|---|
| \`tokenRepositories\` | string | \`""\` | 逗号或换行分隔的 repo 列表 |
| \`tokenOwner\` | string | \`""\` | App 所属 org/user（默认用当前 repo owner） |

两个值原样透传给 \`create-github-app-token\` 的 \`repositories\` / \`owner\` 参数。空字符串时该 action 退化为"当前 repo 范围"（向后兼容）。

## 调用方使用方式

\`\`\`yaml
uses: ReverseGame/java-build/.github/workflows/tauri-build-template-dispatch.yml@main
with:
  useAppToken: true
  tokenRepositories: |
    reverse-bot-gui
    reverse-bot-rs
  # tokenOwner: ReverseGame    # 可选，默认就是当前 repo owner
secrets:
  appId: \${{ vars.MY_APP_ID }}
  appPrivateKey: \${{ secrets.MY_APP_PRIVATE_KEY }}
\`\`\`

## 前置条件

App 必须安装到所有列出的 repo（在 https://github.com/organizations/ReverseGame/settings/installations 给 App 加上 repo access）。

## 测试计划

- [ ] caller 不传 \`tokenRepositories\` → 行为同当前（只覆盖当前 repo）
- [ ] caller 传 \`tokenRepositories: reverse-bot-gui,reverse-bot-rs\` → 日志显示 token 覆盖两个 repo，submodule fetch 成功
- [ ] App 未装到列出的 repo → \`create-github-app-token\` 失败，触发回退到 patToken