### PR TITLE
refactor(workflow): PR body 映射改用 vars.PR_BODY_MAP，移除硬编码 repo 名

### DIFF
--- a/.github/workflows/tauri-build-template-dispatch.yml
+++ b/.github/workflows/tauri-build-template-dispatch.yml
@@ -122,16 +122,8 @@ jobs:
 
       - name: Set PR body based on repository
         id: pr_body
-        env:
-          PR_BODY_MAP: ${{ vars.PR_BODY_MAP }}
         run: |
-          repo_name="${{ steps.update_submodule.outputs.repo_name }}"
-          if [ -n "$PR_BODY_MAP" ]; then
-            body=$(printf '%s' "$PR_BODY_MAP" | jq -r --arg name "$repo_name" '.[$name] // "优化已知问题"')
-          else
-            body="优化已知问题"
-          fi
-          echo "body=$body" >> "$GITHUB_OUTPUT"
+          echo "body=优化已知问题" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7

--- a/.github/workflows/tauri-build-template-dispatch.yml
+++ b/.github/workflows/tauri-build-template-dispatch.yml
@@ -35,7 +35,7 @@ on:
         required: false
         type: string
         default: ""
-        description: "App token 需要访问的 repo 列表（逗号或换行分隔，例: reverse-bot-gui,reverse-bot-rs）。省略则仅当前 repo。"
+        description: "App token 需要访问的 repo 列表（逗号或换行分隔， 省略则仅当前 repo）。"
       tokenOwner:
         required: false
         type: string
@@ -112,26 +112,26 @@ jobs:
           echo "master SHA: $(git rev-parse HEAD)"
           repository="${{ github.event.client_payload.repository }}"
           echo "Updating repository: $repository"
-          # 从完整仓库路径提取仓库名 (如: ReverseGame/reverse-proxy-test -> reverse-proxy-test)
           repo_name=$(basename $repository)
           echo "Local submodule path: $repo_name"
           echo "repo_name=$repo_name" >> $GITHUB_OUTPUT
           git -C $repo_name fetch origin ${{ github.event.client_payload.sha }}
           git -C $repo_name checkout ${{ github.event.client_payload.sha }} --force
-          cd $repo_name 
+          cd $repo_name
           git rev-parse HEAD
 
       - name: Set PR body based on repository
         id: pr_body
+        env:
+          PR_BODY_MAP: ${{ vars.PR_BODY_MAP }}
         run: |
           repo_name="${{ steps.update_submodule.outputs.repo_name }}"
-          if [ "$repo_name" == "reverse-bot-rs" ]; then
-            echo "body=xbot 内核更新" >> $GITHUB_OUTPUT
-          elif [ "$repo_name" == "reverse-proxy-test" ]; then
-            echo "body=代理测试模块更新" >> $GITHUB_OUTPUT
+          if [ -n "$PR_BODY_MAP" ]; then
+            body=$(printf '%s' "$PR_BODY_MAP" | jq -r --arg name "$repo_name" '.[$name] // "优化已知问题"')
           else
-            echo "body=优化已知问题" >> $GITHUB_OUTPUT
+            body="优化已知问题"
           fi
+          echo "body=$body" >> "$GITHUB_OUTPUT"
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7


### PR DESCRIPTION
## 变更摘要

把 `Set PR body` step 里硬编码的 repo 名 + 描述抽到 GitHub Variables `vars.PR_BODY_MAP`，yml 文件里不再出现具体 repo 名。

## 改动前

```yaml
- name: Set PR body based on repository
  id: pr_body
  run: |
    repo_name="${{ steps.update_submodule.outputs.repo_name }}"
    if [ "$repo_name" == "reverse-bot-rs" ]; then
      echo "body=xbot 内核更新" >> $GITHUB_OUTPUT
    elif [ "$repo_name" == "reverse-proxy-test" ]; then
      echo "body=代理测试模块更新" >> $GITHUB_OUTPUT
    else
      echo "body=优化已知问题" >> $GITHUB_OUTPUT
    fi
```

## 改动后

```yaml
- name: Set PR body based on repository
  id: pr_body
  env:
    PR_BODY_MAP: \${{ vars.PR_BODY_MAP }}
  run: |
    repo_name="\${{ steps.update_submodule.outputs.repo_name }}"
    if [ -n "$PR_BODY_MAP" ]; then
      body=$(printf '%s' "$PR_BODY_MAP" | jq -r --arg name "$repo_name" '.[\$name] // "优化已知问题"')
    else
      body="优化已知问题"
    fi
    echo "body=$body" >> "$GITHUB_OUTPUT"
```

顺带清理 `tokenRepositories` description 里出现的示例 repo 名。

## 调用方配置

合并前需要在 **caller repo (reverse-bot-gui)** 或 **org (ReverseGame)** 的 Variables 里加：

```
名称: PR_BODY_MAP
值:   {"reverse-bot-rs":"内核更新","reverse-proxy-test":"代理测试模块更新"}
```

位置：`Settings → Secrets and variables → Actions → Variables 标签 → New repository/organization variable`

新增 repo 只需要改这个 var，不再动 yml。

## Fallback 行为

| 情形 | 结果 |
|---|---|
| vars 未配置 | body = "优化已知问题" |
| vars 配置但 repo 不在 map | body = "优化已知问题" |
| repo 在 map 中 | body = map[repo_name] |
| vars 不是合法 JSON | jq 报错，step 失败（与之前对齐） |

## 注意

vars 不会被 mask，但只有 repo/org admin 能查看。yml 公开可见的 repo 信息已清理干净。

## 测试计划

- [ ] vars 不配置，触发 dispatch → PR body = "优化已知问题"
- [ ] vars 配 `{"reverse-bot-rs":"内核更新"}`，dispatch reverse-bot-rs → PR body = "内核更新"
- [ ] vars 配上述，dispatch 不在 map 的 repo → PR body = "优化已知问题"